### PR TITLE
PR: fix dw dW behavior

### DIFF
--- a/spyder_okvim/utils/helper_motion.py
+++ b/spyder_okvim/utils/helper_motion.py
@@ -281,7 +281,11 @@ class HelperMotion:
         cursor = self.get_cursor()
         for _ in range(num):
             if cursor.atBlockEnd():
-                cursor.movePosition(QTextCursor.NextWord, n=2)
+                cursor.movePosition(QTextCursor.NextWord)
+                if self._get_ch(cursor.position()) in WHITE_SPACE:
+                    cursor.movePosition(QTextCursor.NextWord, n=2)
+                else:
+                    cursor.movePosition(QTextCursor.NextWord)
             else:
                 cursor.movePosition(QTextCursor.NextWord)
 

--- a/spyder_okvim/utils/helper_motion.py
+++ b/spyder_okvim/utils/helper_motion.py
@@ -361,13 +361,12 @@ class HelperMotion:
                 cursor.movePosition(QTextCursor.NextWord)
                 if self._get_ch(cursor.position()) in WHITE_SPACE:
                     cursor.movePosition(QTextCursor.NextWord)
-            else:
+
+            cursor.movePosition(QTextCursor.NextWord)
+            while (self._get_leading_ch(cursor.position()) not in WHITE_SPACE):
+                if cursor.atBlockEnd():
+                    break
                 cursor.movePosition(QTextCursor.NextWord)
-                while (self._get_leading_ch(cursor.position())
-                       not in WHITE_SPACE):
-                    if cursor.atBlockEnd():
-                        break
-                    cursor.movePosition(QTextCursor.NextWord)
 
         return self._set_motion_info(cursor.position(),
                                      motion_type=MotionType.CharWise)

--- a/spyder_okvim/widgets/tests/test_okvim.py
+++ b/spyder_okvim/widgets/tests/test_okvim.py
@@ -996,6 +996,7 @@ def test_W_cmd_in_vline(vim_bot, text, cmd_list, cursor_pos, sel_pos):
     [
         ('01 34', ['b'], 0),
         ('01 34', ['$', 'b'], 3),
+        ('0\n2\n4\n6', ['3j', '3b'], 0),
     ]
 )
 def test_b_cmd(vim_bot, text, cmd_list, cursor_pos):
@@ -1580,6 +1581,8 @@ def test_percent_cmd_in_vline(vim_bot, text, cmd_list, cursor_pos, sel_pos):
     "text, cmd_list, cursor_pos",
     [
         ('', ['f', 'r'], 0),
+        ('', [';'], 0),
+        ('', [','], 0),
         ('\n', ['j', 'f', 'r'], 1),
         ('\n r', ['j', 'f', 'r'], 2),
         ('\n r', ['j', '2', 'f', 'r'], 1),
@@ -2917,6 +2920,7 @@ def test_aw_cmd_in_v(vim_bot, text, cmd_list, cursor_pos, sel_pos):
         (' {01234} ', ['7l', 'v', 'a', '}'], 7, [1, 8]),
         (' {\n(\nasdf)\nasdf} ', ['3l', 'v', 'a', '}'], 15, [1, 16]),
         (' (((kk)))', ['l', 'v', 'a', '('], 8, [1, 9]),
+        (' (((kk)))', ['$', 'v', 'a', '('], 8, [1, 9]),
     ]
 )
 def test_a_bracket_cmd_in_v(vim_bot, text, cmd_list, cursor_pos, sel_pos):
@@ -3556,6 +3560,8 @@ def test_C_cmd_in_normal(vim_bot, text, cmd_list, cursor_pos, text_expected, reg
         ('a.dk b', ['d', 'W'], 0, 'b', '"', 'a.dk '),
         ('  a.dk b', ['d', 'W'], 0, 'a.dk b', '"', '  '),
         ('a.dk\nb', ['d', 'W'], 0, '\nb', '"', 'a.dk'),
+        ('a.dk\nb c', ['d', '2W'], 0, 'c', '"', 'a.dk\nb '),
+        ('a.dk\n b(f) c', ['d', '2W'], 0, 'c', '"', 'a.dk\n b(f) '),
         ('a.dk\nb', ['d', 'e'], 0, 'dk\nb', '"', 'a.'),
         ('a.dk\nb', ['d', '2e'], 0, '\nb', '"', 'a.dk'),
         ('abcd', ['$', 'd', 'b'], 0, 'd', '"', 'abc'),
@@ -3627,6 +3633,10 @@ def test_d_cmd_in_normal(vim_bot, text, cmd_list, cursor_pos, text_expected,
         ('a\n b\nc', ['c', '3w'], 0, '',  '"', 'a\n b\nc'),
         ('a.dk b', ['c', 'W'], 0, ' b', '"', 'a.dk'),
         (' a.dk b', ['c', 'W'], 0, 'a.dk b', '"', ' '),
+        ('a.dk b dd', ['c', '2W'], 0, ' dd', '"', 'a.dk b'),
+        ('a.dk b dd', ['c', '2W'], 0, ' dd', '"', 'a.dk b'),
+        ('b\n a.bc d', ['c', '2W'], 0, ' d', '"', 'b\n a.bc'),
+        ('\n a.bc d', ['c', '2W'], 0, ' d', '"', '\n a.bc'),
         ('a.dk\nb', ['c', 'e'], 0, 'dk\nb', '"', 'a.'),
         ('a.dk\nb', ['c', '2e'], 0, '\nb', '"', 'a.dk'),
         ('abcd', ['$', 'c', 'b'], 0, 'd', '"', 'abc'),
@@ -3681,6 +3691,9 @@ def test_c_cmd_in_normal(vim_bot, text, cmd_list, cursor_pos, text_expected,
         ('a', ['N'], 0,),
         ('a', ['/', 'b', Qt.Key_Escape], 0,),
         ('a', ['/', 'b', '\r'], 0,),
+        ('ddd', ['/', 'd', Qt.Key_Return], 1,),
+        ('ddd', ['/', 'd', Qt.Key_Return, 'n'], 2,),
+        ('ddd', ['/', 'd', Qt.Key_Return, 'n', 'n'], 0,),
         (' dhr\n  dhrwodn\n\ndhrwodn\n   dhrwodn', ['/', 'd', 'h', 'r', Qt.Key_Return], 1,),
         (' dhr\n  dhrwodn\n\ndhrwodn\n   dhrwodn', ['/', 'd', 'h', 'r', Qt.Key_Enter, 'n'], 7,),
         (' dhr\n  dhrwodn\n\ndhrwodn\n   dhrwodn', ['/', 'd', 'h', 'r', Qt.Key_Return, '2n'], 16,),

--- a/spyder_okvim/widgets/tests/test_okvim.py
+++ b/spyder_okvim/widgets/tests/test_okvim.py
@@ -281,6 +281,7 @@ def test_v_cmd(vim_bot, text, cmd_list, cursor_pos, sel_pos):
     "text, cmd_list, cursor_pos, sel_pos",
     [
         ("import numpy as np", ['V'], 0, [0, 18]),
+        ("import numpy as np", ['V', 'l', 'h'], 0, [0, 18]),
         ("import numpy as np", ['V', '5l'], 5, [0, 18]),
         ("import numpy as np", ['5l', 'V'], 5, [0, 18]),
         ("""import numpy as np
@@ -2547,6 +2548,7 @@ def test_gtilde_cmd_in_vline(vim_bot, text, cmd_list, text_expected, cursor_pos)
     [
         ('', ['>', '>'], '', 0),
         ('abcde', ['2l', '>', '>'], '    abcde', 4),
+        ('abcde', ['2l', '>', '%'], 'abcde', 2),
         (' abcde\na', ['l', '>', '>'], '     abcde\na', 5),
         ('a\n\na', ['l', '3>', '>'], '    a\n\n    a', 4),
         ('ab\na\na\nb\nc\nd\ne\n', ['l', '2>', '3>'], '    ab\n    a\n    a\n    b\n    c\n    d\ne\n', 4),
@@ -2632,6 +2634,7 @@ def test_greater_cmd_in_vline(vim_bot, text, cmd_list, text_expected, cursor_pos
     [
         ('', ['<', '<'], '', 0),
         ('    abcde', ['2l', '<', '<'], 'abcde', 0),
+        ('    abcde', ['2l', '<', '%'], '    abcde', 2),
         ('   abcde', ['2l', '<', '<'], 'abcde', 0),
         (' abcde\na', ['l', '<', '<'], 'abcde\na', 0),
         ('    a\n\n    a', ['l', '3<', '<'], 'a\n\na', 0),
@@ -2913,6 +2916,7 @@ def test_aw_cmd_in_v(vim_bot, text, cmd_list, cursor_pos, sel_pos):
         (' {01234} ', ['l', 'v', 'a', '}'], 7, [1, 8]),
         (' {01234} ', ['7l', 'v', 'a', '}'], 7, [1, 8]),
         (' {\n(\nasdf)\nasdf} ', ['3l', 'v', 'a', '}'], 15, [1, 16]),
+        (' (((kk)))', ['l', 'v', 'a', '('], 8, [1, 9]),
     ]
 )
 def test_a_bracket_cmd_in_v(vim_bot, text, cmd_list, cursor_pos, sel_pos):
@@ -3016,6 +3020,7 @@ def test_clipboard(vim_bot):
     [
         ('a', ['y', 'l'], 0, '"', 'a'),
         ('a', ['y', ','], 0, '"', ''),
+        ('a', ['y', 'i', 'b'], 0, '"', ''),
         ('abcd', ['$', 'y', '2h'], 1, '"', 'bc'),
         ('a\nb', ['y', 'j'], 0, '"', 'a\nb\n'),
         ('  a\n b', ['j', 'l', 'y', 'k'], 1, '"', '  a\n b\n'),
@@ -3543,6 +3548,7 @@ def test_C_cmd_in_normal(vim_bot, text, cmd_list, cursor_pos, text_expected, reg
         ('a b', ['d', 'w'], 0, 'b',  '"', 'a '),
         ('a\nb', ['d', 'w'], 0, '\nb',  '"', 'a'),
         ('a\nb', ['d', '2w'], 0, '',  '"', 'a\nb'),
+        ('a\n b', ['d', '2w'], 0, '',  '"', 'a\n b'),
         ('a\nb c\n', ['d', '2w'], 0, 'c\n',  '"', 'a\nb '),
         ('a b', ['l', 'd', 'w'], 1, 'ab',  '"', ' '),
         ('a b c ', ['d', '2w'], 0, 'c ',  '"', 'a b '),
@@ -3616,6 +3622,7 @@ def test_d_cmd_in_normal(vim_bot, text, cmd_list, cursor_pos, text_expected,
         ('a b', ['l', 'c', 'w'], 1, 'ab',  '"', ' '),
         ('a b c ', ['c', '2w'], 0, ' c ',  '"', 'a b'),
         ('a b c ', ['c', '3w'], 0, ' ',  '"', 'a b c'),
+        ('a\n b', ['c', '2w'], 0, '',  '"', 'a\n b'),
         ('a\nb\nc', ['c', '3w'], 0, '',  '"', 'a\nb\nc'),
         ('a\n b\nc', ['c', '3w'], 0, '',  '"', 'a\n b\nc'),
         ('a.dk b', ['c', 'W'], 0, ' b', '"', 'a.dk'),
@@ -3670,6 +3677,8 @@ def test_c_cmd_in_normal(vim_bot, text, cmd_list, cursor_pos, text_expected,
 @pytest.mark.parametrize(
     "text, cmd_list, cursor_pos",
     [
+        ('a', ['n'], 0,),
+        ('a', ['N'], 0,),
         ('a', ['/', 'b', Qt.Key_Escape], 0,),
         ('a', ['/', 'b', '\r'], 0,),
         (' dhr\n  dhrwodn\n\ndhrwodn\n   dhrwodn', ['/', 'd', 'h', 'r', Qt.Key_Return], 1,),


### PR DESCRIPTION
If the cursor is at the end of the block and the next block has a leading white space, dw command skip the the leading white space.