### PR TITLE
PR: Set the extra selection order

### DIFF
--- a/spyder_okvim/utils/helper_motion.py
+++ b/spyder_okvim/utils/helper_motion.py
@@ -1055,7 +1055,8 @@ class HelperMotion:
             else:
                 cursor = editor.document().find(
                         QRegularExpression(txt), cursor)
-        editor.set_extra_selections('vim_search', [i for i in search_stack])
+        self.vim_status.cursor.set_extra_selections(
+            'vim_search', [i for i in search_stack])
         editor.update_extra_selections()
 
         self.vim_status.search.selection_list = search_stack


### PR DESCRIPTION
There was a problem that the occurrence selection had a higher priority than the highlight yank selection, so the highlight selection was not displayed normally.

- Before
![old](https://user-images.githubusercontent.com/22970578/99247724-ad975880-284a-11eb-874d-8311eee85b25.gif)

- After
![new](https://user-images.githubusercontent.com/22970578/99247733-b0924900-284a-11eb-81ee-57d7c9ba1659.gif)
