### PR TITLE
PR: Add path finder

### DIFF
--- a/spyder_okvim/conftest.py
+++ b/spyder_okvim/conftest.py
@@ -69,6 +69,9 @@ class MainMock(QWidget):
         self.plugin_focus_changed = Mock()
         self.editor = EditorMock(editor_stack)
         self.status_bar = StatusBarMock()
+        self.projects = Mock()
+        self.open_file = Mock()
+        self.projects.get_active_project_path = lambda: None
         layout = QVBoxLayout()
         layout.addWidget(self.editor)
         layout.addWidget(self.status_bar)

--- a/spyder_okvim/utils/path_finder.py
+++ b/spyder_okvim/utils/path_finder.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+"""Path Finder."""
+# Standard library imports
+import os.path as osp
+import re
+import sys
+
+# Third party imports
+from qtpy.QtCore import QDir, QDirIterator, QStringListModel, Qt, Signal
+from qtpy.QtWidgets import (
+    QApplication, QDialog, QLineEdit, QListView, QVBoxLayout,)
+
+
+def fuzzyfinder(query, collection):
+    """Fuzzy search.
+
+    Ref: https://github.com/amjith/fuzzyfinder
+
+    Args:
+        input (str): A partial string which is typically entered by a user.
+        collection (iterable): A collection of strings which will be filtered
+                               based on the `input`.
+
+    Returns:
+        suggestions (generator): A generator object that produces a list of
+            suggestions narrowed down from `collection` using the `input`.
+    """
+    suggestions = []
+    pat = '.*?'.join(map(re.escape, query))
+    # lookahead regex to manage overlapping matches
+    pat = '(?=({0}))'.format(pat)
+    regex = re.compile(pat, re.IGNORECASE)
+
+    for txt in collection:
+        r = list(regex.finditer(txt))
+        if r:
+            best = min(r, key=lambda x: len(x.group(1)))  # find shortest match
+            suggestions.append((len(best.group(1)), txt))
+
+    return [z[-1] for z in sorted(suggestions)]
+
+
+class PathFinderEdit(QLineEdit):
+    """Line editor for input of path finder."""
+
+    sig_up_key_pressed = Signal()
+    sig_pg_up_key_pressed = Signal()
+    sig_pg_half_up_key_pressed = Signal()
+    sig_down_key_pressed = Signal()
+    sig_pg_down_key_pressed = Signal()
+    sig_pg_half_down_key_pressed = Signal()
+    sig_enter_key_pressed = Signal()
+    sig_esc_key_pressed = Signal()
+
+    def __init__(self, parent, textChanged):
+        """Init."""
+        super().__init__(parent, textChanged=textChanged)
+        self.dispatcher_nomodifier = {
+            Qt.Key_Up: self.sig_up_key_pressed.emit,
+            Qt.Key_Down: self.sig_down_key_pressed.emit,
+            Qt.Key_Enter: self.sig_enter_key_pressed.emit,
+            Qt.Key_Return: self.sig_enter_key_pressed.emit,
+            Qt.Key_Escape: self.sig_esc_key_pressed.emit,
+            Qt.Key_PageUp: self.sig_pg_up_key_pressed.emit,
+            Qt.Key_PageDown: self.sig_pg_down_key_pressed.emit}
+
+        self.dispatcher_ctrl = {
+            Qt.Key_P: self.sig_up_key_pressed.emit,
+            Qt.Key_B: self.sig_pg_up_key_pressed.emit,
+            Qt.Key_U: self.sig_pg_half_up_key_pressed.emit,
+            Qt.Key_N: self.sig_down_key_pressed.emit,
+            Qt.Key_F: self.sig_pg_down_key_pressed.emit,
+            Qt.Key_D: self.sig_pg_half_down_key_pressed.emit}
+
+    def keyPressEvent(self, e):
+        """Override Qt method."""
+        key = e.key()
+        modifier = e.modifiers()
+        pressed_ctrl = modifier == Qt.ControlModifier
+        pressed_nomodifier = modifier == Qt.NoModifier
+
+        if pressed_nomodifier and key in self.dispatcher_nomodifier.keys():
+            self.dispatcher_nomodifier[key]()
+            return
+
+        if pressed_ctrl and key in self.dispatcher_ctrl.keys():
+            self.dispatcher_ctrl[key]()
+            return
+        super().keyPressEvent(e)
+
+
+class PathFinder(QDialog):
+    """Search path of files in the folder."""
+
+    _MIN_WIDTH = 800
+    _MAX_HEIGHT = 600
+
+    def __init__(self, folder, parent=None):
+        """Init."""
+        super().__init__(parent)
+        self.folder = folder
+        self.path_selected = ""
+        self.path_list = []
+        self.results_old = {}
+        self.setWindowTitle("Path Finder")
+        self.setWindowFlags(Qt.Popup | Qt.FramelessWindowHint)
+        self.setWindowOpacity(0.95)
+        self.setFixedHeight(self._MAX_HEIGHT)
+
+        # Set List widget
+        self.list_viewer = QListView(self)
+        self.list_viewer.setAttribute(Qt.WA_TransparentForMouseEvents)
+        self.list_viewer.setFocusPolicy(Qt.NoFocus)
+        self.list_viewer.setFixedWidth(self._MIN_WIDTH)
+        self.list_viewer.setUniformItemSizes(True)
+        self.list_model = QStringListModel()
+        self.list_viewer.setModel(self.list_model)
+
+        # Set edit
+        self.edit = PathFinderEdit(self, textChanged=self.update_list)
+        self.edit.sig_esc_key_pressed.connect(self.close)
+        self.edit.sig_enter_key_pressed.connect(self.enter)
+
+        self.edit.sig_up_key_pressed.connect(lambda: self.prev_row(1))
+        self.edit.sig_pg_up_key_pressed.connect(self.pg_up)
+        self.edit.sig_pg_half_up_key_pressed.connect(self.pg_half_up)
+
+        self.edit.sig_down_key_pressed.connect(lambda: self.next_row(1))
+        self.edit.sig_pg_down_key_pressed.connect(self.pg_down)
+        self.edit.sig_pg_half_down_key_pressed.connect(self.pg_half_down)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.edit)
+        layout.addWidget(self.list_viewer)
+
+        self.setLayout(layout)
+
+        self.get_path_list()
+        self.update_list()
+
+        self.edit.setFocus()
+
+    def get_number_of_visible_lines(self):
+        """Get the number of visible lines in list."""
+        num_lines = 0
+        lv = self.list_viewer
+        height = lv.visualRect(lv.model().index(0, 0)).height()
+        if height > 0:
+            num_lines = lv.viewport().height() // height
+        return num_lines
+
+    def get_path_list(self):
+        """Get path of files including subdiretorys."""
+        dir_ = QDir(self.folder)
+        it = QDirIterator(
+            self.folder,
+            ['*.py', '*.txt'],
+            QDir.Files | QDir.NoDotAndDotDot | QDir.NoSymLinks,
+            QDirIterator.Subdirectories)
+        while it.hasNext():
+            self.path_list.append(dir_.relativeFilePath(it.next()))
+
+        self.results_old[''] = self.path_list
+
+        if self.folder is None or not osp.isdir(self.folder):
+            self.edit.setPlaceholderText("The project is not valid.")
+
+    def update_list(self):
+        """Update listview."""
+        query = self.edit.text()
+        query = query.replace(" ", '')
+        paths = self.results_old.get(query, None)
+
+        if paths is None:
+            collections = self.results_old.get(query[:-1], self.path_list)
+            paths = fuzzyfinder(query, collections)
+
+        if paths:
+            self.list_model.setStringList(paths)
+            self.list_viewer.setCurrentIndex(self.list_model.index(0))
+
+    def prev_row(self, stride=1):
+        """Select prev row in list viewer."""
+        prev_row = self.list_viewer.currentIndex().row() - stride
+        prev_row = max([prev_row, 0])
+        self.list_viewer.setCurrentIndex(self.list_model.index(prev_row))
+
+    def next_row(self, stride=1):
+        """Select next row in list viewer."""
+        n_row = self.list_model.rowCount()
+        if n_row == 0:
+            return
+        next_row = self.list_viewer.currentIndex().row() + stride
+        next_row = min([next_row, n_row - 1])
+        self.list_viewer.setCurrentIndex(self.list_model.index(next_row))
+
+    def pg_up(self):
+        """Scroll windows 1page backwards."""
+        n_line = self.get_number_of_visible_lines()
+        self.prev_row(n_line)
+
+    def pg_down(self):
+        """Scroll windows 1page forwards."""
+        n_line = self.get_number_of_visible_lines()
+        self.next_row(n_line)
+
+    def pg_half_up(self):
+        """Scroll windows half page backwards."""
+        n_line = self.get_number_of_visible_lines()
+        self.prev_row(n_line // 2)
+
+    def pg_half_down(self):
+        """Scroll windows half page forwards."""
+        n_line = self.get_number_of_visible_lines()
+        self.next_row(n_line // 2)
+
+    def enter(self):
+        """Select next row in list viewer."""
+        idx = self.list_viewer.currentIndex()
+        rel_path = idx.data(Qt.DisplayRole)
+        if rel_path:
+            path = osp.join(self.folder, rel_path)
+            self.path_selected = path
+        self.close()
+

--- a/spyder_okvim/utils/path_finder.py
+++ b/spyder_okvim/utils/path_finder.py
@@ -223,7 +223,7 @@ class PathFinder(QDialog):
         """Select next row in list viewer."""
         idx = self.list_viewer.currentIndex()
         rel_path = idx.data(Qt.DisplayRole)
-        if rel_path:
+        if rel_path and isinstance(self.folder, str):
             path = osp.join(self.folder, rel_path)
             self.path_selected = path
         self.close()

--- a/spyder_okvim/utils/path_finder.py
+++ b/spyder_okvim/utils/path_finder.py
@@ -86,6 +86,7 @@ class PathFinderEdit(QLineEdit):
         if pressed_ctrl and key in self.dispatcher_ctrl.keys():
             self.dispatcher_ctrl[key]()
             return
+
         super().keyPressEvent(e)
 
 
@@ -140,6 +141,10 @@ class PathFinder(QDialog):
 
         self.edit.setFocus()
 
+    def get_path_selected(self):
+        """Get path selected."""
+        return self.path_selected
+
     def get_number_of_visible_lines(self):
         """Get the number of visible lines in list."""
         num_lines = 0
@@ -154,7 +159,7 @@ class PathFinder(QDialog):
         dir_ = QDir(self.folder)
         it = QDirIterator(
             self.folder,
-            ['*.py', '*.txt'],
+            ['*.py', '*.txt', '*.md'],
             QDir.Files | QDir.NoDotAndDotDot | QDir.NoSymLinks,
             QDirIterator.Subdirectories)
         while it.hasNext():

--- a/spyder_okvim/utils/tests/test_path_finder.py
+++ b/spyder_okvim/utils/tests/test_path_finder.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+"""Tests for path finder."""
+# Third party imports
+import pytest
+from qtpy.QtCore import QEvent, Qt
+from qtpy.QtGui import QKeyEvent, QFocusEvent
+
+# Local imports
+from spyder_okvim.utils.path_finder import PathFinder
+from spyder_okvim.confpage import OkvimConfigPage
+
+
+def test_open_path_finder(vim_bot, monkeypatch, tmpdir):
+    """Test open path finder."""
+    _, _, _, vim, qtbot = vim_bot
+
+    fn = tmpdir.join('tmp.txt')
+    fn.write('content')
+    monkeypatch.setattr(PathFinder, "exec_", lambda x: x)
+    monkeypatch.setattr(PathFinder, "get_path_selected", lambda x: str(fn))
+    event = QKeyEvent(QEvent.KeyPress, Qt.Key_P, Qt.ControlModifier)
+    vim.vim_cmd.commandline.keyPressEvent(event)
+
+
+def test_invaild_folder(qtbot):
+    """Test if input of path finder is invalid."""
+    pf = PathFinder(None)
+
+    qtbot.addWidget(pf)
+    pf.show()
+
+    edit = pf.edit
+
+    event = QKeyEvent(QEvent.KeyPress, Qt.Key_P, Qt.ControlModifier)
+    edit.keyPressEvent(event)
+
+    event = QKeyEvent(QEvent.KeyPress, Qt.Key_N, Qt.ControlModifier)
+    edit.keyPressEvent(event)
+
+    event = QKeyEvent(QEvent.KeyPress, Qt.Key_U, Qt.ControlModifier)
+    edit.keyPressEvent(event)
+
+    event = QKeyEvent(QEvent.KeyPress, Qt.Key_D, Qt.ControlModifier)
+    edit.keyPressEvent(event)
+
+    event = QKeyEvent(QEvent.KeyPress, Qt.Key_F, Qt.ControlModifier)
+    edit.keyPressEvent(event)
+
+    event = QKeyEvent(QEvent.KeyPress, Qt.Key_U, Qt.ControlModifier)
+    edit.keyPressEvent(event)
+
+    event = QKeyEvent(QEvent.KeyPress, Qt.Key_Up, Qt.NoModifier)
+    edit.keyPressEvent(event)
+
+    event = QKeyEvent(QEvent.KeyPress, Qt.Key_Down, Qt.NoModifier)
+    edit.keyPressEvent(event)
+
+    event = QKeyEvent(QEvent.KeyPress, Qt.Key_PageUp, Qt.NoModifier)
+    edit.keyPressEvent(event)
+
+    event = QKeyEvent(QEvent.KeyPress, Qt.Key_PageDown, Qt.NoModifier)
+    edit.keyPressEvent(event)
+
+    event = QKeyEvent(QEvent.KeyPress, Qt.Key_Enter, Qt.NoModifier)
+    edit.keyPressEvent(event)
+    assert pf.get_path_selected() == ''
+
+    pf.show()
+    event = QKeyEvent(QEvent.KeyPress, Qt.Key_Escape, Qt.NoModifier)
+    edit.keyPressEvent(event)
+    assert pf.get_path_selected() == ''
+
+
+def test_valid_folder(qtbot, tmpdir):
+    """Test valid folder."""
+    folder = tmpdir.mkdir('projects')
+    for name in ['a', 'ok97465.py', 'test.md', 'fig.txt']:
+        tmp = folder.join(name)
+        tmp.write('contents')
+
+    folder_sub = folder.mkdir('sub1')
+    for name in ['b', 'path_finder.py', '__init__.md', 'config.txt']:
+        tmp = folder_sub.join(name)
+        tmp.write('contents')
+
+    pf = PathFinder(str(folder))
+
+    qtbot.addWidget(pf)
+    pf.show()
+
+    edit = pf.edit
+    lv = pf.list_viewer
+    lm = pf.list_model
+
+    assert lm.rowCount() == 6
+
+    qtbot.keyPress(edit, Qt.Key_N, modifier=Qt.ControlModifier)
+    assert lv.currentIndex().row() == 1
+
+    qtbot.keyPress(edit, Qt.Key_P, modifier=Qt.ControlModifier)
+    assert lv.currentIndex().row() == 0
+
+    qtbot.keyPress(edit, Qt.Key_Down)
+    assert lv.currentIndex().row() == 1
+
+    qtbot.keyPress(edit, Qt.Key_Up)
+    assert lv.currentIndex().row() == 0
+
+    qtbot.keyPress(edit, Qt.Key_D, modifier=Qt.ControlModifier)
+    assert lv.currentIndex().row() > 0
+
+    qtbot.keyPress(edit, Qt.Key_U, modifier=Qt.ControlModifier)
+    qtbot.keyPress(edit, Qt.Key_U, modifier=Qt.ControlModifier)
+    assert lv.currentIndex().row() == 0
+
+    qtbot.keyPress(edit, Qt.Key_F, modifier=Qt.ControlModifier)
+    assert lv.currentIndex().row() > 0
+
+    qtbot.keyPress(edit, Qt.Key_B, modifier=Qt.ControlModifier)
+    qtbot.keyPress(edit, Qt.Key_B, modifier=Qt.ControlModifier)
+    assert lv.currentIndex().row() == 0
+
+    qtbot.keyPress(edit, Qt.Key_PageDown)
+    assert lv.currentIndex().row() > 0
+
+    qtbot.keyPress(edit, Qt.Key_PageUp)
+    assert lv.currentIndex().row() == 0
+
+    qtbot.keyClicks(edit, 'o')
+    assert lm.rowCount() == 2
+
+    qtbot.keyPress(edit, Qt.Key_Backspace)
+    assert lm.rowCount() == 6
+
+    qtbot.keyClicks(edit, 'ok9')
+    qtbot.keyPress(edit, Qt.Key_Enter)
+    assert pf.get_path_selected() != ''
+
+

--- a/spyder_okvim/widgets/okvim.py
+++ b/spyder_okvim/widgets/okvim.py
@@ -10,6 +10,7 @@
 # Standard library imports
 import sys
 import threading
+import os.path as osp
 from functools import wraps
 
 # Third party imports
@@ -24,6 +25,7 @@ from spyder_okvim.executor import (
     ExecutorLeaderKey, ExecutorNormalCmd, ExecutorVisualCmd, ExecutorVlineCmd,)
 from spyder_okvim.utils.vim_status import (
     InputCmdInfo, KeyInfo, VimState, VimStatus,)
+from spyder_okvim.utils.path_finder import PathFinder
 
 running_coverage = 'coverage' in sys.modules
 
@@ -210,6 +212,18 @@ class VimShortcut(QObject):
 
         self.cmd_line.esc_pressed()
 
+    def open_path_finder(self):
+        """Open path finder."""
+        root_folder = self.main.projects.get_active_project_path()
+
+        dlg = PathFinder(root_folder, self.main)
+        dlg.exec_()
+        path = dlg.path_selected
+
+        if osp.isfile(path):
+            self.main.open_file(path)
+            self.vim_status.set_focus_to_vim()
+
 
 class VimStateLabel(QLabel):
     """Display state of vim."""
@@ -264,7 +278,8 @@ class VimLineEdit(QLineEdit):
                            Qt.Key_F: vim_shortcut.pg_down,
                            Qt.Key_U: vim_shortcut.pg_half_up,
                            Qt.Key_B: vim_shortcut.pg_up,
-                           Qt.Key_R: vim_shortcut.redo}
+                           Qt.Key_R: vim_shortcut.redo,
+                           Qt.Key_P: vim_shortcut.open_path_finder}
 
     def to_normal(self):
         """Convert the state of vim to normal mode."""

--- a/spyder_okvim/widgets/okvim.py
+++ b/spyder_okvim/widgets/okvim.py
@@ -218,7 +218,7 @@ class VimShortcut(QObject):
 
         dlg = PathFinder(root_folder, self.main)
         dlg.exec_()
-        path = dlg.path_selected
+        path = dlg.get_path_selected()
 
         if osp.isfile(path):
             self.main.open_file(path)


### PR DESCRIPTION
Fixes #9 

![path_finder](https://user-images.githubusercontent.com/22970578/100749435-00b30300-3428-11eb-8316-2d611f877d27.gif)

The path finder searches files in active project root path.
The path finder searches *.py, *. txt, *.md.

You can use ^p, ^n, ^f, ^b, ^d, ^u to naviagte.