### PR TITLE
Add bookmark mark operation tests

### DIFF
--- a/spyder_okvim/spyder/tests/test_bookmarks.py
+++ b/spyder_okvim/spyder/tests/test_bookmarks.py
@@ -148,3 +148,87 @@ def test_bookmark_removed_after_edit(vim_bot):
     qtbot.keyClicks(cmd_line, "'a")
     assert editor.textCursor().position() == 0
 
+
+@pytest.mark.parametrize(
+    "cmd,text_expected,cursor_pos,reg_expected",
+    [
+        ("y'a", "a\nb\nc\n", 0, "a\nb\nc\n"),
+        ("y`a", "a\nb\nc\n", 0, "a\nb\nc"),
+        ("d'a", "", 0, "a\nb\nc\n"),
+        ("d`a", "\n", 0, "a\nb\nc"),
+        ("c'a", "\n", 0, "a\nb\nc\n"),
+        ("c`a", "\n", 0, "a\nb\nc"),
+    ],
+)
+def test_mark_operations(vim_bot, cmd, text_expected, cursor_pos, reg_expected):
+    """Test y/d/c commands with mark motions."""
+    _, _, editor, vim, qtbot = vim_bot
+    editor.set_text("a\nb\nc\n")
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(0)
+    vim.vim_cmd.vim_status.reset_for_test()
+
+    cmd_line = vim.vim_cmd.commandline
+    qtbot.keyClicks(cmd_line, "ma")
+    qtbot.keyClicks(cmd_line, "2j")
+    qtbot.keyClicks(cmd_line, cmd)
+
+    reg = vim.vim_cmd.vim_status.register_dict['"']
+    assert editor.toPlainText() == text_expected
+    assert editor.textCursor().position() == cursor_pos
+    assert reg.content == reg_expected
+
+
+@pytest.mark.parametrize("cmd", ["y'a", "y`a", "d'a", "d`a", "c'a", "c`a"])
+def test_mark_operations_removed(vim_bot, cmd):
+    """Operations should do nothing if mark was removed."""
+    _, _, editor, vim, qtbot = vim_bot
+    editor.set_text("a\nb\nc\n")
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(4)
+    vim.vim_cmd.vim_status.reset_for_test()
+
+    cmd_line = vim.vim_cmd.commandline
+    qtbot.keyClicks(cmd_line, "ma")
+    editor.set_text("b")
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(0)
+    reg_before = vim.vim_cmd.vim_status.register_dict['"'].content
+    qtbot.keyClicks(cmd_line, cmd)
+    reg_after = vim.vim_cmd.vim_status.register_dict['"'].content
+    assert editor.toPlainText() == "b"
+    assert editor.textCursor().position() == 0
+    assert reg_before == reg_after
+
+
+def test_global_bookmark_removed_after_edit(vim_bot):
+    """Global mark should be cleared if its line is removed."""
+    _, _, editor, vim, qtbot = vim_bot
+    editor.set_text("a\nb\nc\n")
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(0)
+    vim.vim_cmd.vim_status.reset_for_test()
+
+    cmd_line = vim.vim_cmd.commandline
+    qtbot.keyClicks(cmd_line, "mA")
+    editor.set_text("b")
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(0)
+    qtbot.keyClicks(cmd_line, "'A")
+    assert editor.textCursor().position() == 0
+    assert 'A' in vim.vim_cmd.vim_status.bookmarks_global
+
+
+def test_global_bookmark_overwrite(vim_bot):
+    """Setting mA in another file overwrites previous global mark."""
+    _, stack, editor0, vim, qtbot = vim_bot
+    editor0.set_text("a\nb\nc\n")
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(0)
+    vim.vim_cmd.vim_status.reset_for_test()
+
+    cmd_line = vim.vim_cmd.commandline
+    qtbot.keyClicks(cmd_line, "mA")
+    other = next(p for p in stack.get_filenames() if p != stack.get_current_filename())
+    stack.set_current_filename(other)
+    editor_other = stack.get_current_editor()
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(2)
+    qtbot.keyClicks(cmd_line, "mA")
+    stack.set_current_filename(stack.get_filenames()[0])
+    qtbot.keyClicks(cmd_line, "'A")
+    assert stack.get_current_filename() == other
+    assert editor_other.textCursor().position() == 2


### PR DESCRIPTION
## Summary
- add new bookmark operation tests covering `y`, `d`, and `c` with marks
- test behaviour when a mark is removed and with global marks

## Testing
- `QT_QPA_PLATFORM=offscreen pytest spyder_okvim/spyder/tests/test_bookmarks.py::test_mark_operations spyder_okvim/spyder/tests/test_bookmarks.py::test_mark_operations_removed spyder_okvim/spyder/tests/test_bookmarks.py::test_global_bookmark_removed_after_edit spyder_okvim/spyder/tests/test_bookmarks.py::test_global_bookmark_overwrite -q`

------
https://chatgpt.com/codex/tasks/task_e_6852bb4749cc832da27d7a920a2fe1df