### PR TITLE
Support :num line jumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The following motions are supported:
 - w, W, b, e
 - iwW, i()[]{}bB, i'"
 - G, g
+- :{number}
 - ^D, ^U, ^F, ^B
 - HLM
 - %

--- a/spyder_okvim/executor/executor_normal.py
+++ b/spyder_okvim/executor/executor_normal.py
@@ -782,7 +782,7 @@ class ExecutorNormalCmd(ExecutorBase):
         return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
 
     def closesquarebracket(self, num=1, num_str=""):
-        """Start [ submode."""
+        """Start ] submode."""
         executor_sub = self.executor_sub_closesquarebracekt
 
         self.set_parent_info_to_submode(executor_sub, num, num_str)

--- a/spyder_okvim/executor/executor_sub.py
+++ b/spyder_okvim/executor/executor_sub.py
@@ -825,7 +825,7 @@ class ExecutorSubCmd_opensquarebracket(ExecutorSubBase):
 
 
 class ExecutorSubCmd_closesquarebracket(ExecutorSubBase):
-    """submode of ["""
+    """submode of ]"""
 
     def __init__(self, vim_status):
         """."""

--- a/spyder_okvim/executor/executor_visual.py
+++ b/spyder_okvim/executor/executor_visual.py
@@ -13,6 +13,7 @@ from spyder_okvim.executor.executor_base import (
     RETURN_EXECUTOR_METHOD_INFO,
     ExecutorBase,
 )
+from spyder_okvim.executor.executor_colon import ExecutorColon
 from spyder_okvim.executor.executor_easymotion import ExecutorEasymotion
 from spyder_okvim.executor.executor_sub import (
     ExecutorSearch,
@@ -35,7 +36,7 @@ class ExecutorVisualCmd(ExecutorBase):
     def __init__(self, vim_status):
         super().__init__(vim_status)
 
-        cmds = "uUoiaydxscVhHjJklLMwWbBSepP^$gG~%fFtTnN/;,\"`'mr<> \b\r*#"
+        cmds = "uUoiaydxscVhHjJklLMwWbBSepP^$gG~:%fFtTnN/;,\"`'mr<> \b\r*#"
         cmds = ''.join(re.escape(c) for c in cmds)
         self.pattern_cmd = re.compile(r"(\d*)([{}])".format(cmds))
         self.set_cursor_pos = vim_status.cursor.set_cursor_pos
@@ -46,6 +47,7 @@ class ExecutorVisualCmd(ExecutorBase):
         self.set_block_selection_in_visual = (
             self.vim_status.cursor.set_block_selection_in_visual
         )
+        self.executor_colon = ExecutorColon(vim_status)
         self.executor_sub_g = ExecutorSubCmd_g(vim_status)
         self.executor_sub_f_t = ExecutorSubCmd_f_t(vim_status)
         self.executor_sub_r = ExecutorSubCmd_r(vim_status)
@@ -57,6 +59,11 @@ class ExecutorVisualCmd(ExecutorBase):
         self.executor_sub_easymotion = ExecutorEasymotion(vim_status)
         self.executor_sub_sneak = ExecutorSubCmdSneak(vim_status)
         self.executor_sub_surround = ExecutorAddSurround(vim_status)
+
+    def colon(self, num=1, num_str=""):
+        """Start colon mode."""
+        self.vim_status.set_message("")
+        return RETURN_EXECUTOR_METHOD_INFO(self.executor_colon, False)
 
     def zero(self, num=1, num_str=""):
         """Go to the start of the current line."""

--- a/spyder_okvim/executor/executor_vline.py
+++ b/spyder_okvim/executor/executor_vline.py
@@ -13,6 +13,7 @@ from spyder_okvim.executor.executor_base import (
     RETURN_EXECUTOR_METHOD_INFO,
     ExecutorBase,
 )
+from spyder_okvim.executor.executor_colon import ExecutorColon
 from spyder_okvim.executor.executor_easymotion import ExecutorEasymotion
 from spyder_okvim.executor.executor_sub import (
     ExecutorSearch,
@@ -32,7 +33,7 @@ class ExecutorVlineCmd(ExecutorBase):
     def __init__(self, vim_status):
         super().__init__(vim_status)
 
-        cmds = "uUovhydcsSxHjJklLMwWbBepP^$gG~%fFtTnN/;,\"`'mr<> \b\r*#"
+        cmds = "uUovhydcsSxHjJklLMwWbBepP^$gG~:%fFtTnN/;,\"`'mr<> \b\r*#"
         cmds = ''.join(re.escape(c) for c in cmds)
         self.pattern_cmd = re.compile(r"(\d*)([{}])".format(cmds))
         self.set_cursor_pos = vim_status.cursor.set_cursor_pos
@@ -48,6 +49,12 @@ class ExecutorVlineCmd(ExecutorBase):
         self.executor_sub_search = ExecutorSearch(vim_status)
         self.executor_sub_easymotion = ExecutorEasymotion(vim_status)
         self.executor_sub_sneak = ExecutorSubCmdSneak(vim_status)
+        self.executor_colon = ExecutorColon(vim_status)
+
+    def colon(self, num=1, num_str=""):
+        """Start colon mode."""
+        self.vim_status.set_message("")
+        return RETURN_EXECUTOR_METHOD_INFO(self.executor_colon, False)
 
     def zero(self, num=1, num_str=""):
         """Go to the start of the current line."""

--- a/spyder_okvim/executor/tests/test_normal.py
+++ b/spyder_okvim/executor/tests/test_normal.py
@@ -677,6 +677,46 @@ def test_gg_cmd(vim_bot, text, cmd_list, cursor_pos):
 
 
 @pytest.mark.parametrize(
+    "text, cmd_list, cursor_pos",
+    [
+        ("0\n2\n4\n", ["4j", ":", "1", Qt.Key_Return], 0),
+        ("0\n2\n4\n", [":", "2", Qt.Key_Return], 2),
+        ("0\n     \n8\n", [":", "2", Qt.Key_Return], 6),
+        ("0\n2\n4\n", [":", "1", Qt.Key_Return], 0),
+        ("0\n2\n4\n     a", [":", "4", Qt.Key_Return], 11),
+        ("", [":", "1", Qt.Key_Return], 0),
+        ("", [":", "2", Qt.Key_Return], 0),
+        (
+            "aaa\nbbb\nccc\nddd\neee\n",
+            ["j", ":", "4", Qt.Key_Return],
+            12,
+        ),
+        (
+            "aaa\nbbb\nccc\nddd\neee\n",
+            ["j", "2l", ":", "5", Qt.Key_Return],
+            16,
+        ),
+    ],
+)
+def test_colon_num_cmd(vim_bot, text, cmd_list, cursor_pos):
+    """Test :num command."""
+    _, _, editor, vim, qtbot = vim_bot
+    editor.set_text(text)
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(0)
+    vim.vim_cmd.vim_status.reset_for_test()
+
+    cmd_line = vim.vim_cmd.commandline
+    for cmd in cmd_list:
+        if isinstance(cmd, str):
+            qtbot.keyClicks(cmd_line, cmd)
+        else:
+            qtbot.keyPress(cmd_line, cmd)
+
+    assert cmd_line.text() == ""
+    assert editor.textCursor().position() == cursor_pos
+
+
+@pytest.mark.parametrize(
     "text, cmd_list, text_expected, cursor_pos",
     [
         ("abcde", ["~"], "Abcde", 1),

--- a/spyder_okvim/executor/tests/test_visual.py
+++ b/spyder_okvim/executor/tests/test_visual.py
@@ -492,6 +492,43 @@ def test_gg_cmd_in_v(vim_bot, text, cmd_list, cursor_pos, sel_pos):
 
 
 @pytest.mark.parametrize(
+    "text, cmd_list, cursor_pos",
+    [
+        ("0\n2\n4\n", ["v", ":", "2", Qt.Key_Return], 4),
+        ("0\n     \n8\n", ["v", ":", "2", Qt.Key_Return], 8),
+        ("0\n\n2\n4\n", ["v", ":", "3", Qt.Key_Return], 5),
+        (
+            "aaa\nbbb\nccc\nddd\neee\n",
+            ["j", "v", ":", "3", Qt.Key_Return],
+            16,
+        ),
+        (
+            "aaa\nbbb\nccc\nddd\neee\n",
+            ["j", "l", "v", ":", "3", Qt.Key_Return],
+            17,
+        ),
+    ],
+)
+def test_colon_num_cmd_in_v(vim_bot, text, cmd_list, cursor_pos):
+    """Test :num command in visual."""
+    _, _, editor, vim, qtbot = vim_bot
+    editor.set_text(text)
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(0)
+    vim.vim_cmd.vim_status.reset_for_test()
+
+    cmd_line = vim.vim_cmd.commandline
+    for cmd in cmd_list:
+        if isinstance(cmd, str):
+            qtbot.keyClicks(cmd_line, cmd)
+        else:
+            qtbot.keyPress(cmd_line, cmd)
+
+    assert cmd_line.text() == ""
+    assert editor.textCursor().position() == cursor_pos
+    assert not editor.get_extra_selections("vim_selection")
+
+
+@pytest.mark.parametrize(
     "text, cmd_list, text_expected, cursor_pos",
     [
         ("abcde", ["v", "~"], "Abcde", 0),

--- a/spyder_okvim/executor/tests/test_vline.py
+++ b/spyder_okvim/executor/tests/test_vline.py
@@ -401,6 +401,43 @@ def test_gg_cmd_in_vline(vim_bot, text, cmd_list, cursor_pos, sel_pos):
 
 
 @pytest.mark.parametrize(
+    "text, cmd_list, cursor_pos",
+    [
+        ("0\n2\n4\n", ["V", ":", "2", Qt.Key_Return], 4),
+        ("0\n     \n8\n", ["V", ":", "2", Qt.Key_Return], 8),
+        ("0\n\n2\n4\n", ["V", ":", "3", Qt.Key_Return], 5),
+        (
+            "aaa\nbbb\nccc\nddd\neee\n",
+            ["j", "V", ":", "3", Qt.Key_Return],
+            16,
+        ),
+        (
+            "aaa\nbbb\nccc\nddd\neee\n",
+            ["j", "l", "V", ":", "3", Qt.Key_Return],
+            17,
+        ),
+    ],
+)
+def test_colon_num_cmd_in_vline(vim_bot, text, cmd_list, cursor_pos):
+    """Test :num command in vline."""
+    _, _, editor, vim, qtbot = vim_bot
+    editor.set_text(text)
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(0)
+    vim.vim_cmd.vim_status.reset_for_test()
+
+    cmd_line = vim.vim_cmd.commandline
+    for cmd in cmd_list:
+        if isinstance(cmd, str):
+            qtbot.keyClicks(cmd_line, cmd)
+        else:
+            qtbot.keyPress(cmd_line, cmd)
+
+    assert cmd_line.text() == ""
+    assert editor.textCursor().position() == cursor_pos
+    assert not editor.get_extra_selections("vim_selection")
+
+
+@pytest.mark.parametrize(
     "text, cmd_list, text_expected, cursor_pos",
     [
         ("abcde", ["V", "~"], "ABCDE", 0),


### PR DESCRIPTION
## Summary
- enable `:num` in commandline to move to a given line
- allow colon commands in visual and vline modes
- add tests for new behaviour
- document `:{number}` in motions list
- add tests jumping from line 2 with cursor starting in different columns

## Testing
- `python runtests.py` *(passed: 1372 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6853e466ec38832d89db8b1ba47717c2