### PR TITLE
Refactor executors with mixin

### DIFF
--- a/spyder_okvim/executor/decorators.py
+++ b/spyder_okvim/executor/decorators.py
@@ -1,11 +1,23 @@
+"""Decorators for managing submode execution in the Spyder OkVim executor framework.
+
+This module provides decorators to help with entering and managing submodes
+within the executor system. The main decorator, `submode`, wraps command methods
+to prepare submode executors, attach deferred callbacks, and ensure a clean
+context switch using RETURN_EXECUTOR_METHOD_INFO.
+
+Typical usage involves applying the `submode` decorator to executor methods
+that need to transition into a submode, optionally providing a function to
+retrieve a list of deferred functions for the submode.
+"""
+
+from collections.abc import Callable
 from functools import wraps
-from typing import Callable, List
 
 from .executor_base import FUNC_INFO, RETURN_EXECUTOR_METHOD_INFO
 
 
 def submode(
-    func_list_getter: Callable[[object], List[FUNC_INFO]] | None = None,
+    func_list_getter: Callable[[object], list[FUNC_INFO]] | None = None,
     clear_command_line: bool = True,
 ):
     """Return a decorator that prepares and enters a submode.

--- a/spyder_okvim/executor/executor_base.py
+++ b/spyder_okvim/executor/executor_base.py
@@ -9,7 +9,7 @@ object and decide whether submodes should be entered.
 """
 # %% Import
 # Standard library imports
-from typing import Any, List, NamedTuple
+from typing import Any, NamedTuple
 
 from spyder_okvim.utils.helper_action import HelperAction
 
@@ -148,7 +148,7 @@ class ExecutorSubBase(ExecutorBase):
         self.has_zero_cmd = False
         self.parent_num = []
         self.parent_num_str = []
-        self.func_list_deferred: List[FUNC_INFO] = []
+        self.func_list_deferred: list[FUNC_INFO] = []
         self.return_deferred: Any = None
 
     def set_parent_info_to_submode(self, submode, num, num_str):
@@ -159,7 +159,7 @@ class ExecutorSubBase(ExecutorBase):
         submode.parent_num.append(num)
         submode.parent_num_str.append(num_str)
 
-    def set_func_list_deferred(self, f_list: List[FUNC_INFO], ret: Any = None):
+    def set_func_list_deferred(self, f_list: list[FUNC_INFO], ret: Any = None):
         """Set func list."""
         self.func_list_deferred = f_list
         self.return_deferred = ret

--- a/spyder_okvim/executor/executor_easymotion.py
+++ b/spyder_okvim/executor/executor_easymotion.py
@@ -6,9 +6,6 @@ select one with a short key sequence.  This executor provides helper methods
 used by the normal and visual mode executors to implement those jumps.
 """
 # %% Import
-# Standard library imports
-from typing import Tuple
-
 # Third party imports
 from qtpy.QtCore import QPoint
 from qtpy.QtGui import QTextCursor, QTextDocument
@@ -103,7 +100,7 @@ class ExecutorSearchCharEasymotion(ExecutorSubBase):
             self.vim_status.sub_mode = None
             return True
 
-    def get_cursor_pos_of_viewport(self) -> Tuple[int, int]:
+    def get_cursor_pos_of_viewport(self) -> tuple[int, int]:
         """Get the cursor position of viewport of editor."""
         editor = self.vim_status.get_editor()
         start_pos = editor.cursorForPosition(QPoint(0, 0)).position()
@@ -216,7 +213,7 @@ class ExecutorEasymotion(ExecutorSubBase):
             self.vim_status.sub_mode = None
             return True
 
-    def get_cursor_pos_of_viewport(self) -> Tuple[int, int]:
+    def get_cursor_pos_of_viewport(self) -> tuple[int, int]:
         """Get the cursor position of viewport of editor."""
         editor = self.vim_status.get_editor()
         start_pos = editor.cursorForPosition(QPoint(0, 0)).position()

--- a/spyder_okvim/executor/executor_normal.py
+++ b/spyder_okvim/executor/executor_normal.py
@@ -23,6 +23,7 @@ from spyder_okvim.executor.executor_base import (
     RETURN_EXECUTOR_METHOD_INFO,
     ExecutorBase,
 )
+from spyder_okvim.executor.mixins import MovementMixin
 from spyder_okvim.executor.executor_colon import ExecutorColon
 from spyder_okvim.executor.executor_easymotion import ExecutorEasymotion
 from spyder_okvim.executor.executor_sub import (
@@ -46,11 +47,15 @@ from spyder_okvim.spyder.config import CONF_SECTION
 from spyder_okvim.utils.helper_motion import MotionInfo, MotionType
 
 
-class ExecutorNormalCmd(ExecutorBase):
+class ExecutorNormalCmd(MovementMixin, ExecutorBase):
     """Executor for normal mode."""
 
     def __init__(self, vim_status):
         super().__init__(vim_status)
+
+        # MovementMixin hooks
+        self.move_cursor = self.vim_status.cursor.set_cursor_pos
+        self.move_cursor_no_end = self.vim_status.cursor.set_cursor_pos_without_end
 
         cmds = (
             "aAiIvVhHjpPyJkKlLMoOruwWbBegGsSxdcDCnN^$~:%fFtT\"`'m;,.zZ/<> \b\rq@\[\]*#"
@@ -86,16 +91,6 @@ class ExecutorNormalCmd(ExecutorBase):
             vim_status
         )
 
-    def colon(self, num=1, num_str=""):
-        """Enter ``:`` command-line mode."""
-        self.vim_status.set_message("")
-        return RETURN_EXECUTOR_METHOD_INFO(self.executor_colon, False)
-
-    def zero(self, num=1, num_str=""):
-        """Go to the start of the current line."""
-        motion_info = self.helper_motion.zero()
-
-        self.set_cursor_pos(motion_info.cursor_pos)
 
     def a(self, num=1, num_str=""):
         """Append text after the cursor."""
@@ -141,47 +136,6 @@ class ExecutorNormalCmd(ExecutorBase):
         """Start visual mode per line."""
         self.vim_status.to_visual_line()
 
-    def l(self, num=1, num_str=""):
-        """Move cursor to right."""
-        motion_info = self.helper_motion.l(num=num)
-
-        self.vim_status.cursor.set_cursor_pos_without_end(motion_info.cursor_pos)
-
-    def h(self, num=1, num_str=""):
-        """Move cursor to left."""
-        motion_info = self.helper_motion.h(num=num)
-
-        self.set_cursor_pos(motion_info.cursor_pos)
-
-    def k(self, num=1, num_str=""):
-        """Move cursor to up."""
-        motion_info = self.helper_motion.k(num=num)
-
-        self.set_cursor_pos(motion_info.cursor_pos)
-
-    def j(self, num=1, num_str=""):
-        """Move cursor to down."""
-        motion_info = self.helper_motion.j(num=num)
-
-        self.set_cursor_pos(motion_info.cursor_pos)
-
-    def H(self, num=1, num_str=""):
-        """Move cursor to the top of the page."""
-        motion_info = self.helper_motion.H(num=num)
-
-        self.set_cursor_pos(motion_info.cursor_pos)
-
-    def M(self, num=1, num_str=""):
-        """Move cursor to the middle of the page."""
-        motion_info = self.helper_motion.M(num=num)
-
-        self.set_cursor_pos(motion_info.cursor_pos)
-
-    def L(self, num=1, num_str=""):
-        """Move cursor to the bottom of the page."""
-        motion_info = self.helper_motion.L(num=num)
-
-        self.set_cursor_pos(motion_info.cursor_pos)
 
     def J(self, num=1, num_str=""):
         """Join lines, with a minimum of two lines."""
@@ -195,18 +149,6 @@ class ExecutorNormalCmd(ExecutorBase):
         cursor_pos_start = cursor.position()
 
         self.helper_action.join_lines(cursor_pos_start, block_no_start, block_no_end)
-
-    def caret(self, num=1, num_str=""):
-        """Move cursor to the first non-blank character of the line."""
-        motion_info = self.helper_motion.caret(num=num)
-
-        self.set_cursor_pos(motion_info.cursor_pos)
-
-    def dollar(self, num=1, num_str=""):
-        """Move cursor to the end of the line."""
-        motion_info = self.helper_motion.dollar(num=num)
-
-        self.vim_status.cursor.set_cursor_pos_without_end(motion_info.cursor_pos)
 
     def o(self, num=1, num_str=""):
         """Begin a new line below the cursor and insert text."""
@@ -263,35 +205,6 @@ class ExecutorNormalCmd(ExecutorBase):
 
         self.set_cursor_pos(pos)
 
-    def w(self, num=1, num_str=""):
-        """Move to the next word."""
-        motion_info = self.helper_motion.w(num=num)
-
-        self.vim_status.cursor.set_cursor_pos_without_end(motion_info.cursor_pos)
-
-    def W(self, num=1, num_str=""):
-        """Move to the next WORD."""
-        motion_info = self.helper_motion.W(num=num)
-
-        self.vim_status.cursor.set_cursor_pos_without_end(motion_info.cursor_pos)
-
-    def b(self, num=1, num_str=""):
-        """Move to the previous word."""
-        motion_info = self.helper_motion.b(num=num)
-
-        self.set_cursor_pos(motion_info.cursor_pos)
-
-    def B(self, num=1, num_str=""):
-        """Move to the previous WORD."""
-        motion_info = self.helper_motion.B(num=num)
-
-        self.set_cursor_pos(motion_info.cursor_pos)
-
-    def e(self, num=1, num_str=""):
-        """Move to the end of word."""
-        motion_info = self.helper_motion.e(num=num)
-
-        self.set_cursor_pos(motion_info.cursor_pos)
 
     @submode(lambda self: [FUNC_INFO(self.apply_motion_info_in_normal, True)])
     def g(self, num=1, num_str=""):
@@ -318,12 +231,6 @@ class ExecutorNormalCmd(ExecutorBase):
         if cursor.atBlockEnd() and not cursor.atBlockStart():
             self.h(1)
 
-    def percent(self, num=1, num_str=""):
-        """Go to matching bracket."""
-        motion_info = self.helper_motion.percent(num=num, num_str=num_str)
-
-        self.set_cursor_pos(motion_info.cursor_pos)
-
     @submode(lambda self: [FUNC_INFO(self.apply_motion_info_in_normal, True)])
     def f(self, num=1, num_str=""):
         """Go to the next occurrence of a character."""
@@ -344,17 +251,7 @@ class ExecutorNormalCmd(ExecutorBase):
         """Go to the next occurrence of a character."""
         return self.executor_sub_f_t
 
-    def semicolon(self, num=1, num_str=""):
-        """Repeat the last ``f``, ``t``, ``F`` or ``T`` search."""
-        motion_info = self.helper_motion.semicolon(num=num, num_str=num_str)
 
-        self.set_cursor_pos(motion_info.cursor_pos)
-
-    def comma(self, num=1, num_str=""):
-        """Repeat the last ``f``, ``t``, ``F`` or ``T`` in the opposite direction."""
-        motion_info = self.helper_motion.comma(num=num, num_str=num_str)
-
-        self.set_cursor_pos(motion_info.cursor_pos)
 
     def r(self, num=1, num_str=""):
         """Replace the ch under the cursor with input."""
@@ -641,23 +538,6 @@ class ExecutorNormalCmd(ExecutorBase):
 
         self.set_cursor_pos(motion_info.cursor_pos)
 
-    def space(self, num=1, num_str=""):
-        """Move cursor to right."""
-        motion_info = self.helper_motion.space(num=num)
-
-        self.vim_status.cursor.set_cursor_pos_without_end(motion_info.cursor_pos)
-
-    def backspace(self, num=1, num_str=""):
-        """Move cursor to left."""
-        motion_info = self.helper_motion.backspace(num=num)
-
-        self.vim_status.cursor.set_cursor_pos_without_end(motion_info.cursor_pos)
-
-    def enter(self, num=1, num_str=""):
-        """Move cursor to downward."""
-        motion_info = self.helper_motion.enter(num=num)
-
-        self.set_cursor_pos(motion_info.cursor_pos)
 
     def m(self, num=1, num_str=""):
         """Set bookmark with given name."""

--- a/spyder_okvim/executor/executor_visual.py
+++ b/spyder_okvim/executor/executor_visual.py
@@ -21,6 +21,7 @@ from spyder_okvim.executor.executor_base import (
     RETURN_EXECUTOR_METHOD_INFO,
     ExecutorBase,
 )
+from spyder_okvim.executor.mixins import MovementMixin
 from spyder_okvim.executor.executor_colon import ExecutorColon
 from spyder_okvim.executor.executor_easymotion import ExecutorEasymotion
 from spyder_okvim.executor.executor_sub import (
@@ -38,11 +39,15 @@ from spyder_okvim.executor.executor_surround import ExecutorAddSurround
 from spyder_okvim.spyder.config import CONF_SECTION
 
 
-class ExecutorVisualCmd(ExecutorBase):
+class ExecutorVisualCmd(MovementMixin, ExecutorBase):
     """Executor for visual mode."""
 
     def __init__(self, vim_status):
         super().__init__(vim_status)
+
+        # MovementMixin hooks
+        self.move_cursor = vim_status.cursor.set_cursor_pos_in_visual
+        self.move_cursor_no_end = vim_status.cursor.set_cursor_pos_in_visual
 
         cmds = "uUoiaydxscVhHjJklLMwWbBSepP^$gG~:%fFtTnN/;,\"`'mr<> \b\r*#"
         cmds = "".join(re.escape(c) for c in cmds)
@@ -68,56 +73,12 @@ class ExecutorVisualCmd(ExecutorBase):
         self.executor_sub_sneak = ExecutorSubCmdSneak(vim_status)
         self.executor_sub_surround = ExecutorAddSurround(vim_status)
 
-    def colon(self, num=1, num_str=""):
-        """Start colon mode."""
-        self.vim_status.set_message("")
-        return RETURN_EXECUTOR_METHOD_INFO(self.executor_colon, False)
 
-    def zero(self, num=1, num_str=""):
-        """Go to the start of the current line."""
-        motion_info = self.helper_motion.zero()
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
 
     def V(self, num=1, num_str=""):
         """Start Visual mode per line."""
         self.vim_status.to_visual_line()
 
-    def h(self, num=1, num_str=""):
-        """Move cursor to left."""
-        motion_info = self.helper_motion.h(num=num)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
-
-    def k(self, num=1, num_str=""):
-        """Move cursor to up."""
-        motion_info = self.helper_motion.k(num=num)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
-
-    def H(self, num=1, num_str=""):
-        """Move cursor to the top of the page."""
-        motion_info = self.helper_motion.H(num=num)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
-
-    def M(self, num=1, num_str=""):
-        """Move cursor to the middle of the page."""
-        motion_info = self.helper_motion.M(num=num)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
-
-    def L(self, num=1, num_str=""):
-        """Move cursor to the bottom of the page."""
-        motion_info = self.helper_motion.L(num=num)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
-
-    def j(self, num=1, num_str=""):
-        """Move cursor to down."""
-        motion_info = self.helper_motion.j(num=num)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
 
     def J(self, num=1, num_str=""):
         """Join lines, with a minimum of two lines."""
@@ -141,47 +102,7 @@ class ExecutorVisualCmd(ExecutorBase):
 
         self.set_cursor_pos_in_visual(motion_info.cursor_pos)
 
-    def caret(self, num=1, num_str=""):
-        """Move cursor to the first non-blank character of the line."""
-        motion_info = self.helper_motion.caret(num=num)
 
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
-
-    def dollar(self, num=1, num_str=""):
-        """Move cursor to the end of the line."""
-        motion_info = self.helper_motion.dollar(num=num)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
-
-    def w(self, num=1, num_str=""):
-        """Move to the next word."""
-        motion_info = self.helper_motion.w(num=num)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
-
-    def W(self, num=1, num_str=""):
-        """Move to the next WORD."""
-        motion_info = self.helper_motion.W(num=num)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
-
-    def b(self, num=1, num_str=""):
-        """Move to the previous word."""
-        motion_info = self.helper_motion.b(num=num)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
-
-    def B(self, num=1, num_str=""):
-        """Move to the previous WORD."""
-        motion_info = self.helper_motion.B(num=num)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
-
-    def e(self, num=1, num_str=""):
-        """Move to the the end of word."""
-        motion_info = self.helper_motion.e(num=num)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
 
     @submode(lambda self: [FUNC_INFO(self.apply_motion_info_in_visual, True)])
     def g(self, num=1, num_str=""):
@@ -201,11 +122,6 @@ class ExecutorVisualCmd(ExecutorBase):
         """
         self.helper_action.handle_case(None, "swap")
 
-    def percent(self, num=1, num_str=""):
-        """Go to matching bracket."""
-        motion_info = self.helper_motion.percent(num=num, num_str=num_str)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
 
     @submode(lambda self: [FUNC_INFO(self.apply_motion_info_in_visual, True)])
     def f(self, num=1, num_str=""):
@@ -227,17 +143,7 @@ class ExecutorVisualCmd(ExecutorBase):
         """Go to the next occurrence of a character."""
         return self.executor_sub_f_t
 
-    def semicolon(self, num=1, num_str=""):
-        """Repeat the last ``f``, ``t``, ``F`` or ``T`` search."""
-        motion_info = self.helper_motion.semicolon(num=num, num_str=num_str)
 
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
-
-    def comma(self, num=1, num_str=""):
-        """Repeat the last ``f``, ``t``, ``F`` or ``T`` in the opposite direction."""
-        motion_info = self.helper_motion.comma(num=num, num_str=num_str)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
 
     def r(self, num=1, num_str=""):
         """Replace the selected text under the cursor with input."""
@@ -418,23 +324,7 @@ class ExecutorVisualCmd(ExecutorBase):
         """Put the text from register."""
         self.helper_action.paste_in_visual(num)
 
-    def space(self, num=1, num_str=""):
-        """Move cursor to right."""
-        motion_info = self.helper_motion.space(num=num)
 
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
-
-    def backspace(self, num=1, num_str=""):
-        """Move cursor to left."""
-        motion_info = self.helper_motion.backspace(num=num)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
-
-    def enter(self, num=1, num_str=""):
-        """Move cursor to down."""
-        motion_info = self.helper_motion.enter(num=num)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
 
     def m(self, num=1, num_str=""):
         """Set bookmark with given name."""

--- a/spyder_okvim/executor/executor_vline.py
+++ b/spyder_okvim/executor/executor_vline.py
@@ -13,6 +13,7 @@ from spyder_okvim.executor.executor_base import (
     RETURN_EXECUTOR_METHOD_INFO,
     ExecutorBase,
 )
+from spyder_okvim.executor.mixins import MovementMixin
 from spyder_okvim.executor.executor_colon import ExecutorColon
 from spyder_okvim.executor.executor_easymotion import ExecutorEasymotion
 from spyder_okvim.executor.executor_sub import (
@@ -27,11 +28,15 @@ from spyder_okvim.executor.executor_sub import (
 from spyder_okvim.spyder.config import CONF_SECTION
 
 
-class ExecutorVlineCmd(ExecutorBase):
+class ExecutorVlineCmd(MovementMixin, ExecutorBase):
     """Executor for vline."""
 
     def __init__(self, vim_status):
         super().__init__(vim_status)
+
+        # MovementMixin hooks
+        self.move_cursor = vim_status.cursor.set_cursor_pos_in_vline
+        self.move_cursor_no_end = vim_status.cursor.set_cursor_pos_in_vline
 
         cmds = "uUovhydcsSxHjJklLMwWbBepP^$gG~:%fFtTnN/;,\"`'mr<> \b\r*#"
         cmds = "".join(re.escape(c) for c in cmds)
@@ -51,56 +56,13 @@ class ExecutorVlineCmd(ExecutorBase):
         self.executor_sub_sneak = ExecutorSubCmdSneak(vim_status)
         self.executor_colon = ExecutorColon(vim_status)
 
-    def colon(self, num=1, num_str=""):
-        """Start colon mode."""
-        self.vim_status.set_message("")
-        return RETURN_EXECUTOR_METHOD_INFO(self.executor_colon, False)
 
-    def zero(self, num=1, num_str=""):
-        """Go to the start of the current line."""
-        motion_info = self.helper_motion.zero()
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
 
     def v(self, num=1, num_str=""):
         """Start Visual mode per character."""
         self.vim_status.to_visual_char()
 
-    def h(self, num=1, num_str=""):
-        """Move cursor to left."""
-        motion_info = self.helper_motion.h(num=num)
 
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
-
-    def k(self, num=1, num_str=""):
-        """Move cursor to up."""
-        motion_info = self.helper_motion.k(num=num)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
-
-    def j(self, num=1, num_str=""):
-        """Move cursor to down."""
-        motion_info = self.helper_motion.j(num=num)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
-
-    def H(self, num=1, num_str=""):
-        """Move cursor to the top of the page."""
-        motion_info = self.helper_motion.H(num=num)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
-
-    def M(self, num=1, num_str=""):
-        """Move cursor to the middle of the page."""
-        motion_info = self.helper_motion.M(num=num)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
-
-    def L(self, num=1, num_str=""):
-        """Move cursor to the bottom of the page."""
-        motion_info = self.helper_motion.L(num=num)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
 
     def J(self, num=1, num_str=""):
         """Join lines, with a minimum of two lines."""
@@ -118,53 +80,8 @@ class ExecutorVlineCmd(ExecutorBase):
         self.helper_action.join_lines(cursor_pos_start, block_no_start, block_no_end)
         self.vim_status.to_normal()
 
-    def l(self, num=1, num_str=""):
-        """Move cursor to right."""
-        motion_info = self.helper_motion.l(num=num)
 
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
 
-    def caret(self, num=1, num_str=""):
-        """Move cursor to the first non-blank character of the line."""
-        motion_info = self.helper_motion.caret(num=num)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
-
-    def dollar(self, num=1, num_str=""):
-        """Move cursor to the end of the line."""
-        motion_info = self.helper_motion.dollar(num=num)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
-
-    def w(self, num=1, num_str=""):
-        """Move to the next word."""
-        motion_info = self.helper_motion.w(num=num)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
-
-    def W(self, num=1, num_str=""):
-        """Move to the next WORD."""
-        motion_info = self.helper_motion.W(num=num)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
-
-    def b(self, num=1, num_str=""):
-        """Move to the previous word."""
-        motion_info = self.helper_motion.b(num=num)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
-
-    def B(self, num=1, num_str=""):
-        """Move to the previous WORD."""
-        motion_info = self.helper_motion.B(num=num)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
-
-    def e(self, num=1, num_str=""):
-        """Move to the end of the word."""
-        motion_info = self.helper_motion.e(num=num)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
 
     def g(self, num=1, num_str=""):
         """Start g submode."""
@@ -190,11 +107,6 @@ class ExecutorVlineCmd(ExecutorBase):
         """
         self.helper_action.handle_case(None, "swap")
 
-    def percent(self, num=1, num_str=""):
-        """Go to matching bracket."""
-        motion_info = self.helper_motion.percent(num=num, num_str=num_str)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
 
     def f(self, num=1, num_str=""):
         """Go to the next occurrence of a character."""
@@ -244,17 +156,7 @@ class ExecutorVlineCmd(ExecutorBase):
 
         return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
 
-    def semicolon(self, num=1, num_str=""):
-        """Repeat the last ``f``, ``t``, ``F`` or ``T`` search."""
-        motion_info = self.helper_motion.semicolon(num=num, num_str=num_str)
 
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
-
-    def comma(self, num=1, num_str=""):
-        """Repeat the last ``f``, ``t``, ``F`` or ``T`` in the opposite direction."""
-        motion_info = self.helper_motion.comma(num=num, num_str=num_str)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
 
     def r(self, num=1, num_str=""):
         """Replace the selected text under the cursor with input."""
@@ -429,23 +331,7 @@ class ExecutorVlineCmd(ExecutorBase):
         """Put the text from register."""
         self.helper_action.paste_in_vline(num)
 
-    def space(self, num=1, num_str=""):
-        """Move cursor to right."""
-        motion_info = self.helper_motion.space(num=num)
 
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
-
-    def backspace(self, num=1, num_str=""):
-        """Move cursor to left."""
-        motion_info = self.helper_motion.backspace(num=num)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
-
-    def enter(self, num=1, num_str=""):
-        """Move cursor to down."""
-        motion_info = self.helper_motion.enter(num=num)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
 
     def m(self, num=1, num_str=""):
         """Set bookmark with given name."""

--- a/spyder_okvim/executor/mixins.py
+++ b/spyder_okvim/executor/mixins.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+"""Mixin classes used by command executors."""
+
+from typing import Callable
+
+from spyder_okvim.executor.executor_base import RETURN_EXECUTOR_METHOD_INFO
+
+
+class MovementMixin:
+    """Provide cursor movement commands for various executor classes.
+
+    Subclasses must define ``move_cursor`` and ``move_cursor_no_end`` attributes
+    pointing to callables that move the cursor to the given position.  The
+    ``move_cursor_no_end`` method is used for motions that should not place the
+    cursor at the end of a line.
+    """
+
+    move_cursor: Callable[[int], None]
+    move_cursor_no_end: Callable[[int], None]
+
+    # ------------------------------------------------------------------
+    # Generic commands shared by normal, visual and vline executors
+    # ------------------------------------------------------------------
+    def colon(self, num: int = 1, num_str: str = ""):
+        """Enter ``:`` command-line mode."""
+        self.vim_status.set_message("")
+        return RETURN_EXECUTOR_METHOD_INFO(self.executor_colon, False)
+
+    # ------------------------------------------------------------------
+    # Basic cursor movement commands shared by multiple executors
+    # ------------------------------------------------------------------
+    def zero(self, num: int = 1, num_str: str = ""):
+        """Move to the first column of the current line."""
+        motion_info = self.helper_motion.zero()
+        self.move_cursor(motion_info.cursor_pos)
+
+    def h(self, num: int = 1, num_str: str = ""):
+        """Move cursor left."""
+        motion_info = self.helper_motion.h(num=num)
+        self.move_cursor(motion_info.cursor_pos)
+
+    def j(self, num: int = 1, num_str: str = ""):
+        """Move cursor down."""
+        motion_info = self.helper_motion.j(num=num)
+        self.move_cursor(motion_info.cursor_pos)
+
+    def k(self, num: int = 1, num_str: str = ""):
+        """Move cursor up."""
+        motion_info = self.helper_motion.k(num=num)
+        self.move_cursor(motion_info.cursor_pos)
+
+    def l(self, num: int = 1, num_str: str = ""):
+        """Move cursor right."""
+        motion_info = self.helper_motion.l(num=num)
+        self.move_cursor_no_end(motion_info.cursor_pos)
+
+    def H(self, num: int = 1, num_str: str = ""):
+        """Move cursor to the top of the page."""
+        motion_info = self.helper_motion.H(num=num)
+        self.move_cursor(motion_info.cursor_pos)
+
+    def M(self, num: int = 1, num_str: str = ""):
+        """Move cursor to the middle of the page."""
+        motion_info = self.helper_motion.M(num=num)
+        self.move_cursor(motion_info.cursor_pos)
+
+    def L(self, num: int = 1, num_str: str = ""):
+        """Move cursor to the bottom of the page."""
+        motion_info = self.helper_motion.L(num=num)
+        self.move_cursor(motion_info.cursor_pos)
+
+    def caret(self, num: int = 1, num_str: str = ""):
+        """Move to the first non-blank character of the line."""
+        motion_info = self.helper_motion.caret(num=num)
+        self.move_cursor(motion_info.cursor_pos)
+
+    def dollar(self, num: int = 1, num_str: str = ""):
+        """Move cursor to the end of the line."""
+        motion_info = self.helper_motion.dollar(num=num)
+        self.move_cursor_no_end(motion_info.cursor_pos)
+
+    def w(self, num: int = 1, num_str: str = ""):
+        """Move to the next word."""
+        motion_info = self.helper_motion.w(num=num)
+        self.move_cursor_no_end(motion_info.cursor_pos)
+
+    def W(self, num: int = 1, num_str: str = ""):
+        """Move to the next WORD."""
+        motion_info = self.helper_motion.W(num=num)
+        self.move_cursor_no_end(motion_info.cursor_pos)
+
+    def b(self, num: int = 1, num_str: str = ""):
+        """Move to the previous word."""
+        motion_info = self.helper_motion.b(num=num)
+        self.move_cursor(motion_info.cursor_pos)
+
+    def B(self, num: int = 1, num_str: str = ""):
+        """Move to the previous WORD."""
+        motion_info = self.helper_motion.B(num=num)
+        self.move_cursor(motion_info.cursor_pos)
+
+    def e(self, num: int = 1, num_str: str = ""):
+        """Move to the end of the current word."""
+        motion_info = self.helper_motion.e(num=num)
+        self.move_cursor(motion_info.cursor_pos)
+
+    def percent(self, num: int = 1, num_str: str = ""):
+        """Go to the matching bracket."""
+        motion_info = self.helper_motion.percent(num=num, num_str=num_str)
+        self.move_cursor(motion_info.cursor_pos)
+
+    def semicolon(self, num: int = 1, num_str: str = ""):
+        """Repeat the last f/t search."""
+        motion_info = self.helper_motion.semicolon(num=num, num_str=num_str)
+        self.move_cursor(motion_info.cursor_pos)
+
+    def comma(self, num: int = 1, num_str: str = ""):
+        """Repeat the last f/t search in opposite direction."""
+        motion_info = self.helper_motion.comma(num=num, num_str=num_str)
+        self.move_cursor(motion_info.cursor_pos)
+
+    def space(self, num: int = 1, num_str: str = ""):
+        """Move cursor right (space key)."""
+        motion_info = self.helper_motion.space(num=num)
+        self.move_cursor_no_end(motion_info.cursor_pos)
+
+    def backspace(self, num: int = 1, num_str: str = ""):
+        """Move cursor left (backspace key)."""
+        motion_info = self.helper_motion.backspace(num=num)
+        self.move_cursor_no_end(motion_info.cursor_pos)
+
+    def enter(self, num: int = 1, num_str: str = ""):
+        """Move cursor down (enter key)."""
+        motion_info = self.helper_motion.enter(num=num)
+        self.move_cursor(motion_info.cursor_pos)

--- a/spyder_okvim/utils/bookmark_manager.py
+++ b/spyder_okvim/utils/bookmark_manager.py
@@ -6,7 +6,7 @@ import json
 import os
 import os.path as osp
 from collections import defaultdict
-from typing import Callable, Dict
+from collections.abc import Callable
 
 
 class BookmarkManager:
@@ -26,8 +26,8 @@ class BookmarkManager:
         self.get_editor = get_editor_func
         self.set_cursor_pos = set_cursor_pos_func
 
-        self.bookmarks: Dict[str, Dict[str, Dict[str, int]]] = defaultdict(dict)
-        self.bookmarks_global: Dict[str, Dict[str, int]] = {}
+        self.bookmarks: dict[str, dict[str, dict[str, int]]] = defaultdict(dict)
+        self.bookmarks_global: dict[str, dict[str, int]] = {}
         self._load_persistent_bookmarks()
 
     # ------------------------------------------------------------------

--- a/spyder_okvim/utils/easymotion.py
+++ b/spyder_okvim/utils/easymotion.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 """Implementation of EasyMotion overlays."""
+
 # Standard library imports
-from typing import List
 from itertools import product
 
 # Third party imports
-from qtpy.QtCore import QObject, Qt, QEvent, QCoreApplication
-from qtpy.QtGui import QPen, QColor, QPainter
+from qtpy.QtCore import QCoreApplication, QEvent, QObject, Qt
+from qtpy.QtGui import QColor, QPainter, QPen
 from qtpy.QtWidgets import QPlainTextEdit, QWidget
 
 
@@ -14,10 +14,10 @@ class ManageMarkerEasymotion:
     """Manage markers of easymotion."""
 
     def __init__(self):
-        self.position_list: List[int] = []
-        self.name_list: List[str] = []
+        self.position_list: list[int] = []
+        self.name_list: list[str] = []
 
-        self.marker_keys: List[str] = []
+        self.marker_keys: list[str] = []
         self.init_marker_keys()
         self.motion_type = None
 
@@ -29,7 +29,7 @@ class ManageMarkerEasymotion:
         self.marker_keys = list(keys1)
         self.marker_keys += ["".join(pro) for pro in product(keys2, keys1)]
 
-    def set_positions(self, position_list: List[int], motion_type):
+    def set_positions(self, position_list: list[int], motion_type):
         """Set positions."""
         self.name_list = []
         self.position_list = position_list

--- a/spyder_okvim/utils/helper_motion.py
+++ b/spyder_okvim/utils/helper_motion.py
@@ -4,7 +4,6 @@
 # Standard library imports
 import re
 from bisect import bisect_left, bisect_right
-from typing import Optional
 
 # Third party imports
 from qtpy.QtCore import QPoint, QRegularExpression
@@ -995,7 +994,7 @@ class HelperMotion:
 
     def get_pos_bracket(
         self, num: int, bracket: str, cursor_pos: int
-    ) -> tuple[Optional[int], Optional[int]]:
+    ) -> tuple[int | None, int | None]:
         """Get the position of the bracket block."""
         # Todo: apply num
         pair_bracket = {

--- a/spyder_okvim/utils/vim_status.py
+++ b/spyder_okvim/utils/vim_status.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Container for the state shared by all executors."""
+
 # Standard library imports
 import os.path as osp
 from collections import defaultdict
-from typing import List
 
 # Third party imports
 from qtpy.QtCore import QEvent, QObject, QRegularExpression, Qt, QTimer, Signal, Slot
@@ -959,7 +959,7 @@ class VimStatus(QObject):
         """Add key event from editor to list to macro_manager."""
         self.manager_macro.add_editor_keyevent(event)
 
-    def set_marker_for_easymotion(self, positions: List[int], motion_type):
+    def set_marker_for_easymotion(self, positions: list[int], motion_type):
         """Set marker for easymotion."""
         if not positions:
             return


### PR DESCRIPTION
## Summary
- introduce `MovementMixin` providing common cursor and colon commands
- use the mixin in normal, visual and vline executors
- remove duplicated movement methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a804b34c832d93731099e07ace5f