### PR TITLE
Refactor selection executors with mixin

### DIFF
--- a/spyder_okvim/executor/executor_visual.py
+++ b/spyder_okvim/executor/executor_visual.py
@@ -35,11 +35,11 @@ from spyder_okvim.executor.executor_sub import (
     ExecutorSubMotion_i,
 )
 from spyder_okvim.executor.executor_surround import ExecutorAddSurround
-from spyder_okvim.executor.mixins import MovementMixin
+from spyder_okvim.executor.mixins import MovementMixin, SelectionMixin
 from spyder_okvim.spyder.config import CONF_SECTION
 
 
-class ExecutorVisualCmd(MovementMixin, ExecutorBase):
+class ExecutorVisualCmd(SelectionMixin, MovementMixin, ExecutorBase):
     """Executor for visual mode."""
 
     def __init__(self, vim_status):
@@ -72,6 +72,11 @@ class ExecutorVisualCmd(MovementMixin, ExecutorBase):
         self.executor_sub_easymotion = ExecutorEasymotion(vim_status)
         self.executor_sub_sneak = ExecutorSubCmdSneak(vim_status)
         self.executor_sub_surround = ExecutorAddSurround(vim_status)
+
+        # SelectionMixin hooks
+        self.apply_motion_info_in_sel = self.apply_motion_info_in_visual
+        self.set_cursor_pos_in_sel = self.set_cursor_pos_in_visual
+        self.paste_in_sel = self.helper_action.paste_in_visual
 
     def V(self, num=1, num_str=""):
         """Start Visual mode per line."""
@@ -137,39 +142,6 @@ class ExecutorVisualCmd(MovementMixin, ExecutorBase):
         """Go to the next occurrence of a character."""
         return self.executor_sub_f_t
 
-    def r(self, num=1, num_str=""):
-        """Replace the selected text under the cursor with input."""
-        executor_sub = self.executor_sub_r
-        executor_sub.pos_start = self.get_pos_start_in_selection()
-        executor_sub.pos_end = self.get_pos_end_in_selection()
-
-        self.set_parent_info_to_submode(executor_sub, num, num_str)
-
-        executor_sub.set_func_list_deferred(
-            [
-                FUNC_INFO(self.vim_status.to_normal, False),
-                FUNC_INFO(lambda: self.set_cursor_pos(executor_sub.pos_start), False),
-            ]
-        )
-
-        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
-
-    def greater(self, num=1, num_str=""):
-        """Shift lines rightwards."""
-        sel_start = self.get_pos_start_in_selection()
-        sel_end = self.get_pos_end_in_selection()
-        self.helper_action._indent(sel_start, sel_end)
-        self.vim_status.to_normal()
-        self.vim_status.cursor.draw_vim_cursor()
-
-    def less(self, num=1, num_str=""):
-        """Shift lines leftwards."""
-        sel_start = self.get_pos_start_in_selection()
-        sel_end = self.get_pos_end_in_selection()
-        self.helper_action._unindent(sel_start, sel_end)
-        self.vim_status.to_normal()
-        self.vim_status.cursor.draw_vim_cursor()
-
     def i(self, num=1, num_str=""):
         """Select block exclusively."""
         executor_sub = self.executor_sub_motion_i
@@ -194,16 +166,6 @@ class ExecutorVisualCmd(MovementMixin, ExecutorBase):
 
         return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
 
-    def quote(self, num=1, num_str=""):
-        """Set the name of register."""
-        executor_sub = self.executor_sub_register
-
-        self.set_parent_info_to_submode(executor_sub, num, num_str)
-
-        executor_sub.set_func_list_deferred([])
-
-        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
-
     def d(self, num=1, num_str=""):
         """Delete text."""
         sel_start, sel_end = self.helper_action.yank(None)
@@ -214,39 +176,6 @@ class ExecutorVisualCmd(MovementMixin, ExecutorBase):
         if cursor.atBlockEnd() and not cursor.atBlockStart():
             self.set_cursor_pos(sel_start - 1)
 
-    def x(self, num=1, num_str=""):
-        """Delete text."""
-        self.d(num, num_str)
-
-    def c(self, num=1, num_str=""):
-        """Delete text and start insert."""
-        sel_start, sel_end = self.helper_action.yank(None)
-        self.helper_action.delete(None, is_insert=True)
-        self.vim_status.to_normal()
-        self.set_cursor_pos(sel_start)
-        self.get_editor().setFocus()
-
-    def s(self, num=1, num_str=""):
-        """Delete text and start insert."""
-        use_sneak = CONF.get(CONF_SECTION, "use_sneak")
-        if use_sneak:
-            executor_sub = self.executor_sub_sneak
-
-            self.set_parent_info_to_submode(executor_sub, num, num_str)
-
-            executor_sub.set_func_list_deferred(
-                [
-                    FUNC_INFO(self.apply_motion_info_in_visual, True),
-                    FUNC_INFO(
-                        self.helper_motion.display_another_group_after_sneak, False
-                    ),
-                ]
-            )
-
-            return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
-        else:
-            self.c(num, num_str)
-
     def S(self, num=1, num_str=""):
         """Add surroundings: parentheses, brackets, quotes."""
         self.vim_status.set_message("")
@@ -256,138 +185,3 @@ class ExecutorVisualCmd(MovementMixin, ExecutorBase):
         executor_sub.pos_end = self.get_pos_end_in_selection()
 
         return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
-
-    def y(self, num=1, num_str=""):
-        """Yank selected text."""
-        sel_start, sel_end = self.helper_action.yank(None, is_explicit=True)
-
-        self.vim_status.to_normal()
-        self.set_cursor_pos(sel_start)
-
-    def slash(self, num=1, num_str=""):
-        """Go to the next searched text."""
-        self.vim_status.set_message("")
-        executor_sub = self.executor_sub_search
-
-        self.set_parent_info_to_submode(executor_sub, num, num_str)
-
-        executor_sub.set_func_list_deferred(
-            [FUNC_INFO(self.apply_motion_info_in_visual, True)]
-        )
-
-        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, False)
-
-    def n(self, num=1, num_str=""):
-        """Go to the next searched text."""
-        motion_info = self.helper_motion.n(num=num, num_str=num_str)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
-
-    def N(self, num=1, num_str=""):
-        """Go to the previous searched text."""
-        motion_info = self.helper_motion.N(num=num, num_str=num_str)
-
-        self.set_cursor_pos_in_visual(motion_info.cursor_pos)
-
-    def o(self, num=1, num_str=""):
-        """Go to other end of highlighted text."""
-        sel_start = self.vim_status.get_pos_start_in_selection()
-        sel_end = self.vim_status.get_pos_end_in_selection()
-        cur_pos = self.get_cursor().position()
-        if abs(sel_start - cur_pos) < abs(sel_end - cur_pos):
-            new_pos = sel_end - 1
-        else:
-            new_pos = sel_start
-        self.set_cursor_pos(new_pos)
-
-    def u(self, num=1, num_str=""):
-        """Make txt lowercase and move cursor to the start of selection."""
-        self.helper_action.handle_case(None, "lower")
-
-    def U(self, num=1, num_str=""):
-        """Make txt uppercase and move cursor to the start of selection."""
-        self.helper_action.handle_case(None, "upper")
-
-    def p(self, num=1, num_str=""):
-        """Put the text from register."""
-        self.helper_action.paste_in_visual(num)
-
-    def P(self, num=1, num_str=""):
-        """Put the text from register."""
-        self.helper_action.paste_in_visual(num)
-
-    def m(self, num=1, num_str=""):
-        """Set bookmark with given name."""
-        executor_sub = self.executor_sub_alnum
-        self.set_parent_info_to_submode(executor_sub, num, num_str)
-        executor_sub.set_func_list_deferred(
-            [FUNC_INFO(self.vim_status.set_bookmark, True)]
-        )
-        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
-
-    def apostrophe(self, num=1, num_str=""):
-        """Jump to bookmark linewise keeping visual mode."""
-        executor_sub = self.executor_sub_alnum
-        self.set_parent_info_to_submode(executor_sub, num, num_str)
-
-        def run(ch):
-            if ch.isupper():
-                cur = self.vim_status.get_editorstack().get_current_filename()
-                self.vim_status.jump_to_bookmark(ch)
-                new = self.vim_status.get_editorstack().get_current_filename()
-                if cur == new:
-                    cursor = self.get_cursor()
-                    self.set_cursor_pos_in_visual(cursor.block().position())
-                else:
-                    cursor = self.get_cursor()
-                    self.set_cursor_pos(cursor.block().position())
-                    self.vim_status.to_normal()
-            else:
-                info = self.helper_motion.apostrophe(ch)
-                if info.cursor_pos is not None:
-                    self.set_cursor_pos_in_visual(info.cursor_pos)
-
-        executor_sub.set_func_list_deferred([FUNC_INFO(run, True)])
-        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
-
-    def backtick(self, num=1, num_str=""):
-        """Jump to bookmark charwise keeping visual mode."""
-        executor_sub = self.executor_sub_alnum
-        self.set_parent_info_to_submode(executor_sub, num, num_str)
-
-        def run(ch):
-            if ch.isupper():
-                cur = self.vim_status.get_editorstack().get_current_filename()
-                self.vim_status.jump_to_bookmark(ch)
-                new = self.vim_status.get_editorstack().get_current_filename()
-                if cur != new:
-                    self.vim_status.to_normal()
-            else:
-                info = self.helper_motion.backtick(ch)
-                if info.cursor_pos is not None:
-                    self.set_cursor_pos_in_visual(info.cursor_pos)
-
-        executor_sub.set_func_list_deferred([FUNC_INFO(run, True)])
-        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
-
-    def run_easymotion(self, num=1, num_str=""):
-        """Run easymotion."""
-        executor_sub = self.executor_sub_easymotion
-
-        self.set_parent_info_to_submode(executor_sub, num, num_str)
-
-        executor_sub.set_func_list_deferred(
-            [FUNC_INFO(self.apply_motion_info_in_visual, True)]
-        )
-
-        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
-
-    def asterisk(self, num=1, num_str=""):
-        """Search word under cursor forward."""
-        motion_info = self.helper_motion.asterisk(num)
-        self.apply_motion_info_in_visual(motion_info)
-
-    def sharp(self, num=1, num_str=""):
-        """Search word under cursor backward."""
-        motion_info = self.helper_motion.sharp(num)
-        self.apply_motion_info_in_visual(motion_info)

--- a/spyder_okvim/executor/executor_vline.py
+++ b/spyder_okvim/executor/executor_vline.py
@@ -24,11 +24,11 @@ from spyder_okvim.executor.executor_sub import (
     ExecutorSubCmd_register,
     ExecutorSubCmdSneak,
 )
-from spyder_okvim.executor.mixins import MovementMixin
+from spyder_okvim.executor.mixins import MovementMixin, SelectionMixin
 from spyder_okvim.spyder.config import CONF_SECTION
 
 
-class ExecutorVlineCmd(MovementMixin, ExecutorBase):
+class ExecutorVlineCmd(SelectionMixin, MovementMixin, ExecutorBase):
     """Executor for vline."""
 
     def __init__(self, vim_status):
@@ -55,6 +55,11 @@ class ExecutorVlineCmd(MovementMixin, ExecutorBase):
         self.executor_sub_easymotion = ExecutorEasymotion(vim_status)
         self.executor_sub_sneak = ExecutorSubCmdSneak(vim_status)
         self.executor_colon = ExecutorColon(vim_status)
+
+        # SelectionMixin hooks
+        self.apply_motion_info_in_sel = self.apply_motion_info_in_vline
+        self.set_cursor_pos_in_sel = self.set_cursor_pos_in_vline
+        self.paste_in_sel = self.helper_action.paste_in_vline
 
     def v(self, num=1, num_str=""):
         """Start Visual mode per character."""
@@ -148,49 +153,6 @@ class ExecutorVlineCmd(MovementMixin, ExecutorBase):
 
         return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
 
-    def r(self, num=1, num_str=""):
-        """Replace the selected text under the cursor with input."""
-        executor_sub = self.executor_sub_r
-        executor_sub.pos_start = self.get_pos_start_in_selection()
-        executor_sub.pos_end = self.get_pos_end_in_selection()
-
-        self.set_parent_info_to_submode(executor_sub, num, num_str)
-
-        executor_sub.set_func_list_deferred(
-            [
-                FUNC_INFO(self.vim_status.to_normal, False),
-                FUNC_INFO(lambda: self.set_cursor_pos(executor_sub.pos_start), False),
-            ]
-        )
-
-        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
-
-    def greater(self, num=1, num_str=""):
-        """Shift lines rightwards."""
-        sel_start = self.get_pos_start_in_selection()
-        sel_end = self.get_pos_end_in_selection()
-        self.helper_action._indent(sel_start, sel_end)
-        self.vim_status.to_normal()
-        self.vim_status.cursor.draw_vim_cursor()
-
-    def less(self, num=1, num_str=""):
-        """Shift lines leftwards."""
-        sel_start = self.get_pos_start_in_selection()
-        sel_end = self.get_pos_end_in_selection()
-        self.helper_action._unindent(sel_start, sel_end)
-        self.vim_status.to_normal()
-        self.vim_status.cursor.draw_vim_cursor()
-
-    def quote(self, num=1, num_str=""):
-        """Set the name of register."""
-        executor_sub = self.executor_sub_register
-
-        self.set_parent_info_to_submode(executor_sub, num, num_str)
-
-        executor_sub.set_func_list_deferred([])
-
-        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
-
     def d(self, num=1, num_str=""):
         """Delete text."""
         editor = self.get_editor()
@@ -210,39 +172,6 @@ class ExecutorVlineCmd(MovementMixin, ExecutorBase):
 
         self.set_cursor_pos(cursor_pos)
 
-    def x(self, num=1, num_str=""):
-        """Delete text."""
-        self.d(num, num_str)
-
-    def c(self, num=1, num_str=""):
-        """Delete text and start insert."""
-        sel_start, sel_end = self.helper_action.yank(None)
-        self.helper_action.delete(None, is_insert=True)
-        self.vim_status.to_normal()
-        self.set_cursor_pos(sel_start)
-        self.get_editor().setFocus()
-
-    def s(self, num=1, num_str=""):
-        """Delete text and start insert."""
-        use_sneak = CONF.get(CONF_SECTION, "use_sneak")
-        if use_sneak:
-            executor_sub = self.executor_sub_sneak
-
-            self.set_parent_info_to_submode(executor_sub, num, num_str)
-
-            executor_sub.set_func_list_deferred(
-                [
-                    FUNC_INFO(self.apply_motion_info_in_vline, True),
-                    FUNC_INFO(
-                        self.helper_motion.display_another_group_after_sneak, False
-                    ),
-                ]
-            )
-
-            return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
-        else:
-            self.c(num, num_str)
-
     def S(self, num=1, num_str=""):
         """Delete text and start insert."""
         use_sneak = CONF.get(CONF_SECTION, "use_sneak")
@@ -261,138 +190,3 @@ class ExecutorVlineCmd(MovementMixin, ExecutorBase):
             )
 
             return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
-
-    def y(self, num=1, num_str=""):
-        """Yank selected text."""
-        sel_start, sel_end = self.helper_action.yank(None, is_explicit=True)
-
-        self.vim_status.to_normal()
-        self.set_cursor_pos(sel_start)
-
-    def slash(self, num=1, num_str=""):
-        """Go to the next searched text."""
-        self.vim_status.set_message("")
-        executor_sub = self.executor_sub_search
-
-        self.set_parent_info_to_submode(executor_sub, num, num_str)
-
-        executor_sub.set_func_list_deferred(
-            [FUNC_INFO(self.apply_motion_info_in_vline, True)]
-        )
-
-        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, False)
-
-    def n(self, num=1, num_str=""):
-        """Go to the next searched text."""
-        motion_info = self.helper_motion.n(num=num, num_str=num_str)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
-
-    def N(self, num=1, num_str=""):
-        """Go to the previous searched text."""
-        motion_info = self.helper_motion.N(num=num, num_str=num_str)
-
-        self.set_cursor_pos_in_vline(motion_info.cursor_pos)
-
-    def o(self, num=1, num_str=""):
-        """Go to other end of highlighted text."""
-        sel_start = self.vim_status.get_pos_start_in_selection()
-        sel_end = self.vim_status.get_pos_end_in_selection()
-        cur_pos = self.get_cursor().position()
-        if abs(sel_start - cur_pos) < abs(sel_end - cur_pos):
-            new_pos = sel_end - 1
-        else:
-            new_pos = sel_start
-        self.set_cursor_pos(new_pos)
-
-    def u(self, num=1, num_str=""):
-        """Make txt lowercase and move cursor to the start of selection."""
-        self.helper_action.handle_case(None, "lower")
-
-    def U(self, num=1, num_str=""):
-        """Make txt uppercase and move cursor to the start of selection."""
-        self.helper_action.handle_case(None, "upper")
-
-    def p(self, num=1, num_str=""):
-        """Put the text from register."""
-        self.helper_action.paste_in_vline(num)
-
-    def P(self, num=1, num_str=""):
-        """Put the text from register."""
-        self.helper_action.paste_in_vline(num)
-
-    def m(self, num=1, num_str=""):
-        """Set bookmark with given name."""
-        executor_sub = self.executor_sub_alnum
-        self.set_parent_info_to_submode(executor_sub, num, num_str)
-        executor_sub.set_func_list_deferred(
-            [FUNC_INFO(self.vim_status.set_bookmark, True)]
-        )
-        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
-
-    def apostrophe(self, num=1, num_str=""):
-        """Jump to bookmark linewise keeping vline mode."""
-        executor_sub = self.executor_sub_alnum
-        self.set_parent_info_to_submode(executor_sub, num, num_str)
-
-        def run(ch):
-            if ch.isupper():
-                cur = self.vim_status.get_editorstack().get_current_filename()
-                self.vim_status.jump_to_bookmark(ch)
-                new = self.vim_status.get_editorstack().get_current_filename()
-                if cur == new:
-                    cursor = self.get_cursor()
-                    self.set_cursor_pos_in_vline(cursor.block().position())
-                else:
-                    cursor = self.get_cursor()
-                    self.set_cursor_pos(cursor.block().position())
-                    self.vim_status.to_normal()
-            else:
-                info = self.helper_motion.apostrophe(ch)
-                if info.cursor_pos is not None:
-                    self.set_cursor_pos_in_vline(info.cursor_pos)
-
-        executor_sub.set_func_list_deferred([FUNC_INFO(run, True)])
-        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
-
-    def backtick(self, num=1, num_str=""):
-        """Jump to bookmark charwise keeping vline mode."""
-        executor_sub = self.executor_sub_alnum
-        self.set_parent_info_to_submode(executor_sub, num, num_str)
-
-        def run(ch):
-            if ch.isupper():
-                cur = self.vim_status.get_editorstack().get_current_filename()
-                self.vim_status.jump_to_bookmark(ch)
-                new = self.vim_status.get_editorstack().get_current_filename()
-                if cur != new:
-                    self.vim_status.to_normal()
-            else:
-                info = self.helper_motion.backtick(ch)
-                if info.cursor_pos is not None:
-                    self.set_cursor_pos_in_vline(info.cursor_pos)
-
-        executor_sub.set_func_list_deferred([FUNC_INFO(run, True)])
-        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
-
-    def run_easymotion(self, num=1, num_str=""):
-        """Run easymotion."""
-        executor_sub = self.executor_sub_easymotion
-
-        self.set_parent_info_to_submode(executor_sub, num, num_str)
-
-        executor_sub.set_func_list_deferred(
-            [FUNC_INFO(self.apply_motion_info_in_vline, True)]
-        )
-
-        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
-
-    def asterisk(self, num=1, num_str=""):
-        """Search word under cursor forward."""
-        motion_info = self.helper_motion.asterisk(num)
-        self.apply_motion_info_in_vline(motion_info)
-
-    def sharp(self, num=1, num_str=""):
-        """Search word under cursor backward."""
-        motion_info = self.helper_motion.sharp(num)
-        self.apply_motion_info_in_vline(motion_info)

--- a/spyder_okvim/executor/mixins.py
+++ b/spyder_okvim/executor/mixins.py
@@ -3,7 +3,9 @@
 
 from typing import Callable
 
-from spyder_okvim.executor.executor_base import RETURN_EXECUTOR_METHOD_INFO
+from spyder.config.manager import CONF
+from spyder_okvim.executor.executor_base import FUNC_INFO, RETURN_EXECUTOR_METHOD_INFO
+from spyder_okvim.spyder.config import CONF_SECTION
 
 
 class MovementMixin:
@@ -133,3 +135,211 @@ class MovementMixin:
         """Move cursor down (enter key)."""
         motion_info = self.helper_motion.enter(num=num)
         self.move_cursor(motion_info.cursor_pos)
+
+
+class SelectionMixin:
+    """Common operations for visual and block-visual executors."""
+
+    # Hooks provided by subclasses
+    apply_motion_info_in_sel: Callable[[object], None]
+    set_cursor_pos_in_sel: Callable[[int], None]
+    paste_in_sel: Callable[[int], None]
+
+    # ------------------------------------------------------------------
+    # Selection manipulation helpers
+    # ------------------------------------------------------------------
+    def r(self, num: int = 1, num_str: str = ""):
+        """Replace selection with a typed character."""
+        executor_sub = self.executor_sub_r
+        executor_sub.pos_start = self.get_pos_start_in_selection()
+        executor_sub.pos_end = self.get_pos_end_in_selection()
+
+        self.set_parent_info_to_submode(executor_sub, num, num_str)
+        executor_sub.set_func_list_deferred(
+            [
+                FUNC_INFO(self.vim_status.to_normal, False),
+                FUNC_INFO(lambda: self.set_cursor_pos(executor_sub.pos_start), False),
+            ]
+        )
+
+        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
+
+    def greater(self, num: int = 1, num_str: str = ""):
+        """Indent the selected text."""
+        sel_start = self.get_pos_start_in_selection()
+        sel_end = self.get_pos_end_in_selection()
+        self.helper_action._indent(sel_start, sel_end)
+        self.vim_status.to_normal()
+        self.vim_status.cursor.draw_vim_cursor()
+
+    def less(self, num: int = 1, num_str: str = ""):
+        """Unindent the selected text."""
+        sel_start = self.get_pos_start_in_selection()
+        sel_end = self.get_pos_end_in_selection()
+        self.helper_action._unindent(sel_start, sel_end)
+        self.vim_status.to_normal()
+        self.vim_status.cursor.draw_vim_cursor()
+
+    def quote(self, num: int = 1, num_str: str = ""):
+        """Switch register name."""
+        executor_sub = self.executor_sub_register
+        self.set_parent_info_to_submode(executor_sub, num, num_str)
+        executor_sub.set_func_list_deferred([])
+        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
+
+    def x(self, num: int = 1, num_str: str = ""):
+        """Alias for ``d``."""
+        self.d(num, num_str)
+
+    def c(self, num: int = 1, num_str: str = ""):
+        """Delete selection and enter insert mode."""
+        sel_start, _ = self.helper_action.yank(None)
+        self.helper_action.delete(None, is_insert=True)
+        self.vim_status.to_normal()
+        self.set_cursor_pos(sel_start)
+        self.get_editor().setFocus()
+
+    def s(self, num: int = 1, num_str: str = ""):
+        """Replace selection using sneak if enabled."""
+        use_sneak = CONF.get(CONF_SECTION, "use_sneak")
+        if use_sneak:
+            executor_sub = self.executor_sub_sneak
+            self.set_parent_info_to_submode(executor_sub, num, num_str)
+            executor_sub.set_func_list_deferred(
+                [
+                    FUNC_INFO(self.apply_motion_info_in_sel, True),
+                    FUNC_INFO(
+                        self.helper_motion.display_another_group_after_sneak, False
+                    ),
+                ]
+            )
+            return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
+        else:
+            self.c(num, num_str)
+
+    def y(self, num: int = 1, num_str: str = ""):
+        """Yank selection into register."""
+        sel_start, _ = self.helper_action.yank(None, is_explicit=True)
+        self.vim_status.to_normal()
+        self.set_cursor_pos(sel_start)
+
+    def slash(self, num: int = 1, num_str: str = ""):
+        """Enter search submode and execute motion on return."""
+        self.vim_status.set_message("")
+        executor_sub = self.executor_sub_search
+        self.set_parent_info_to_submode(executor_sub, num, num_str)
+        executor_sub.set_func_list_deferred(
+            [FUNC_INFO(self.apply_motion_info_in_sel, True)]
+        )
+        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, False)
+
+    def n(self, num: int = 1, num_str: str = ""):
+        """Jump to next search occurrence."""
+        motion_info = self.helper_motion.n(num=num, num_str=num_str)
+        self.set_cursor_pos_in_sel(motion_info.cursor_pos)
+
+    def N(self, num: int = 1, num_str: str = ""):
+        """Jump to previous search occurrence."""
+        motion_info = self.helper_motion.N(num=num, num_str=num_str)
+        self.set_cursor_pos_in_sel(motion_info.cursor_pos)
+
+    def o(self, num: int = 1, num_str: str = ""):
+        """Move cursor to the opposite end of the selection."""
+        sel_start = self.vim_status.get_pos_start_in_selection()
+        sel_end = self.vim_status.get_pos_end_in_selection()
+        cur_pos = self.get_cursor().position()
+        new_pos = (
+            sel_end - 1
+            if abs(sel_start - cur_pos) < abs(sel_end - cur_pos)
+            else sel_start
+        )
+        self.set_cursor_pos(new_pos)
+
+    def u(self, num: int = 1, num_str: str = ""):
+        """Lowercase selected text."""
+        self.helper_action.handle_case(None, "lower")
+
+    def U(self, num: int = 1, num_str: str = ""):
+        """Uppercase selected text."""
+        self.helper_action.handle_case(None, "upper")
+
+    def p(self, num: int = 1, num_str: str = ""):
+        """Paste contents of register over the selection."""
+        self.paste_in_sel(num)
+
+    def P(self, num: int = 1, num_str: str = ""):
+        """Paste contents of register over the selection."""
+        self.paste_in_sel(num)
+
+    def m(self, num: int = 1, num_str: str = ""):
+        """Set a bookmark name."""
+        executor_sub = self.executor_sub_alnum
+        self.set_parent_info_to_submode(executor_sub, num, num_str)
+        executor_sub.set_func_list_deferred(
+            [FUNC_INFO(self.vim_status.set_bookmark, True)]
+        )
+        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
+
+    def apostrophe(self, num: int = 1, num_str: str = ""):
+        """Jump to a bookmark linewise and keep selection."""
+        executor_sub = self.executor_sub_alnum
+        self.set_parent_info_to_submode(executor_sub, num, num_str)
+
+        def run(ch: str):
+            if ch.isupper():
+                cur = self.vim_status.get_editorstack().get_current_filename()
+                self.vim_status.jump_to_bookmark(ch)
+                new = self.vim_status.get_editorstack().get_current_filename()
+                if cur == new:
+                    cursor = self.get_cursor()
+                    self.set_cursor_pos_in_sel(cursor.block().position())
+                else:
+                    cursor = self.get_cursor()
+                    self.set_cursor_pos(cursor.block().position())
+                    self.vim_status.to_normal()
+            else:
+                info = self.helper_motion.apostrophe(ch)
+                if info.cursor_pos is not None:
+                    self.set_cursor_pos_in_sel(info.cursor_pos)
+
+        executor_sub.set_func_list_deferred([FUNC_INFO(run, True)])
+        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
+
+    def backtick(self, num: int = 1, num_str: str = ""):
+        """Jump to a bookmark charwise and keep selection."""
+        executor_sub = self.executor_sub_alnum
+        self.set_parent_info_to_submode(executor_sub, num, num_str)
+
+        def run(ch: str):
+            if ch.isupper():
+                cur = self.vim_status.get_editorstack().get_current_filename()
+                self.vim_status.jump_to_bookmark(ch)
+                new = self.vim_status.get_editorstack().get_current_filename()
+                if cur != new:
+                    self.vim_status.to_normal()
+            else:
+                info = self.helper_motion.backtick(ch)
+                if info.cursor_pos is not None:
+                    self.set_cursor_pos_in_sel(info.cursor_pos)
+
+        executor_sub.set_func_list_deferred([FUNC_INFO(run, True)])
+        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
+
+    def run_easymotion(self, num: int = 1, num_str: str = ""):
+        """Invoke the EasyMotion submode."""
+        executor_sub = self.executor_sub_easymotion
+        self.set_parent_info_to_submode(executor_sub, num, num_str)
+        executor_sub.set_func_list_deferred(
+            [FUNC_INFO(self.apply_motion_info_in_sel, True)]
+        )
+        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
+
+    def asterisk(self, num: int = 1, num_str: str = ""):
+        """Search forward for word under the cursor."""
+        motion_info = self.helper_motion.asterisk(num)
+        self.apply_motion_info_in_sel(motion_info)
+
+    def sharp(self, num: int = 1, num_str: str = ""):
+        """Search backward for word under the cursor."""
+        motion_info = self.helper_motion.sharp(num)
+        self.apply_motion_info_in_sel(motion_info)


### PR DESCRIPTION
## Summary
- introduce `SelectionMixin` for shared visual/vline functionality
- apply mixin in `ExecutorVisualCmd` and `ExecutorVlineCmd`
- remove duplicated methods across executors
- update imports and hooks for new mixin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d2ee8570832db690cd6c566638a8