### PR TITLE
Refactor widget module and constant imports

### DIFF
--- a/doc/design_patterns.md
+++ b/doc/design_patterns.md
@@ -12,6 +12,6 @@ Each executor class (`ExecutorNormalCmd`, `ExecutorVisualCmd`, etc.) interprets 
 
 ## Strategy Pattern
 
-Movement and action logic is delegated to helper classes (`HelperMotion`, `HelperAction`). Executors choose which helper method to call depending on the command, enabling different strategies for cursor movement or text manipulation.
+Movement and action logic is delegated to helper classes (`MotionHelper`, `ActionHelper`). Executors choose which helper method to call depending on the command, enabling different strategies for cursor movement or text manipulation.
 
 By separating concerns across these components, the codebase remains modular and adheres to the SOLID principles of single responsibility and open/closed design.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,10 @@ Source = "https://github.com/ok97465/spyder_okvim"
 
 [project.entry-points."spyder.plugins"]
 spyder_okvim = "spyder_okvim.spyder.plugin:OkVim"
+
+[tool.isort]
+profile = "black"
+line_length = 88
+import_heading_stdlib = "Standard Libraries"
+import_heading_thirdparty = "Third Party Libraries"
+import_heading_firstparty = "Project Libraries"

--- a/spyder_okvim/conftest.py
+++ b/spyder_okvim/conftest.py
@@ -1,13 +1,13 @@
 """Conftest."""
 
-# Standard library imports
+# Standard Libraries
 import os
 import os.path as osp
 from unittest.mock import Mock
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
-# Third party imports
+# Third Party Libraries
 import pytest
 import requests
 from pytestqt.plugin import QtBot
@@ -16,7 +16,7 @@ from qtpy.QtWidgets import QVBoxLayout, QWidget
 from spyder.config.manager import CONF
 from spyder.plugins.editor.widgets.editorstack import EditorStack
 
-# Local imports
+# Project Libraries
 from spyder_okvim.spyder.config import CONF_DEFAULTS, CONF_SECTION
 from spyder_okvim.spyder.plugin import OkVim
 

--- a/spyder_okvim/executor/decorators.py
+++ b/spyder_okvim/executor/decorators.py
@@ -10,6 +10,7 @@ that need to transition into a submode, optionally providing a function to
 retrieve a list of deferred functions for the submode.
 """
 
+# Standard Libraries
 from collections.abc import Callable
 from functools import wraps
 

--- a/spyder_okvim/executor/executor_base.py
+++ b/spyder_okvim/executor/executor_base.py
@@ -3,18 +3,17 @@
 
 This module provides :class:`ExecutorBase` and :class:`ExecutorSubBase`, which
 handle the parsing of command strings and delegation of actions to the
-``HelperMotion`` and ``HelperAction`` utilities.  Executors interpret user
+``MotionHelper`` and ``ActionHelper`` utilities. Executors interpret user
 keystrokes, update the shared :class:`~spyder_okvim.utils.vim_status.VimStatus`
 object and decide whether submodes should be entered.
 """
-# %% Import
-# Standard library imports
+
+# Standard Libraries
 from typing import Any, NamedTuple
 
-from spyder_okvim.utils.helper_action import HelperAction
-
-# Local imports
-from spyder_okvim.utils.helper_motion import HelperMotion
+# Project Libraries
+from spyder_okvim.utils.action_helpers import ActionHelper
+from spyder_okvim.utils.motion_helpers import MotionHelper
 
 FUNC_INFO = NamedTuple("FUNC_INFO", [("func", Any), ("has_arg", bool)])
 RETURN_EXECUTOR_METHOD_INFO = NamedTuple(
@@ -74,8 +73,8 @@ class ExecutorBase:
         self.get_pos_start_in_selection = vim_status.get_pos_start_in_selection
         self.get_pos_end_in_selection = vim_status.get_pos_end_in_selection
         self.set_cursor_pos = vim_status.cursor.set_cursor_pos
-        self.helper_motion = HelperMotion(vim_status)
-        self.helper_action = HelperAction(vim_status)
+        self.helper_motion = MotionHelper(vim_status)
+        self.helper_action = ActionHelper(vim_status)
 
         self.has_zero_cmd = True
         self.pattern_cmd = None

--- a/spyder_okvim/executor/executor_colon.py
+++ b/spyder_okvim/executor/executor_colon.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Executor for ":" command-line input."""
-# Local imports
+
+# Project Libraries
 from spyder_okvim.executor.executor_base import ExecutorSubBase
 from spyder_okvim.utils.vim_status import VimState
 

--- a/spyder_okvim/executor/executor_easymotion.py
+++ b/spyder_okvim/executor/executor_easymotion.py
@@ -5,17 +5,17 @@ EasyMotion highlights possible jump targets in the editor and lets the user
 select one with a short key sequence.  This executor provides helper methods
 used by the normal and visual mode executors to implement those jumps.
 """
-# %% Import
-# Third party imports
+
+# Third Party Libraries
 from qtpy.QtCore import QPoint
 from qtpy.QtGui import QTextCursor, QTextDocument
 
-# Local imports
+# Project Libraries
 from spyder_okvim.executor.executor_base import (
     RETURN_EXECUTOR_METHOD_INFO,
     ExecutorSubBase,
 )
-from spyder_okvim.utils.helper_motion import MotionInfo, MotionType
+from spyder_okvim.utils.motion_helpers import MotionInfo, MotionType
 
 
 class ExecutorSelectMarkerEasymotion(ExecutorSubBase):

--- a/spyder_okvim/executor/executor_leader.py
+++ b/spyder_okvim/executor/executor_leader.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 """Executor handling leader-key sequences."""
-# %% Import
-# Local imports
+
+# Third Party Libraries
 from qtpy.QtCore import QTimer
 
+# Project Libraries
 from spyder_okvim.executor.executor_base import ExecutorBase
 
 

--- a/spyder_okvim/executor/executor_normal.py
+++ b/spyder_okvim/executor/executor_normal.py
@@ -6,18 +6,17 @@ when the editor is in *normal* mode.  Commands are dispatched to helper classes
 for motion and editing actions.  The executor can also switch into various
 submodes such as search or register selection.
 """
-# %% Import
-# Standard library imports
+
+# Standard Libraries
 import re
 
-# Third party imports
+# Third Party Libraries
 from qtpy.QtCore import QEvent, Qt
 from qtpy.QtGui import QKeyEvent, QTextCursor
 from spyder.config.manager import CONF
 
+# Project Libraries
 from spyder_okvim.executor.decorators import submode
-
-# Local imports
 from spyder_okvim.executor.executor_base import (
     FUNC_INFO,
     RETURN_EXECUTOR_METHOD_INFO,
@@ -44,7 +43,7 @@ from spyder_okvim.executor.executor_sub import (
 )
 from spyder_okvim.executor.mixins import MovementMixin
 from spyder_okvim.spyder.config import CONF_SECTION
-from spyder_okvim.utils.helper_motion import MotionInfo, MotionType
+from spyder_okvim.utils.motion_helpers import MotionInfo, MotionType
 
 
 class ExecutorNormalCmd(MovementMixin, ExecutorBase):

--- a/spyder_okvim/executor/executor_sub.py
+++ b/spyder_okvim/executor/executor_sub.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 """Collection of executor classes for various submodes."""
-# %% Import
-# Standard library imports
+
+# Standard Libraries
 import re
 
-# Third party imports
+# Third Party Libraries
 from spyder.config.manager import CONF
 
-# Local imports
+# Project Libraries
 from spyder_okvim.executor.executor_base import (
     FUNC_INFO,
     RETURN_EXECUTOR_METHOD_INFO,

--- a/spyder_okvim/executor/executor_surround.py
+++ b/spyder_okvim/executor/executor_surround.py
@@ -1,8 +1,8 @@
 """Executors for manipulating surrounding characters."""
 
-# Local imports
+# Project Libraries
 from spyder_okvim.executor.executor_base import ExecutorSubBase
-from spyder_okvim.utils.helper_motion import MotionInfo, MotionType
+from spyder_okvim.utils.motion_helpers import MotionInfo, MotionType
 
 SURROUNDINGS = "'\"{[()]}"
 

--- a/spyder_okvim/executor/executor_visual.py
+++ b/spyder_okvim/executor/executor_visual.py
@@ -6,16 +6,15 @@ active.  Many commands mirror those from :mod:`executor_normal`, but they act on
 the current selection.  The executor can also enter submodes to handle searches,
 character motions and other modal operations.
 """
-# %% Import
-# Standard library imports
+
+# Standard Libraries
 import re
 
-# Third party imports
+# Third Party Libraries
 from spyder.config.manager import CONF
 
+# Project Libraries
 from spyder_okvim.executor.decorators import submode
-
-# Local imports
 from spyder_okvim.executor.executor_base import (
     FUNC_INFO,
     RETURN_EXECUTOR_METHOD_INFO,

--- a/spyder_okvim/executor/executor_vline.py
+++ b/spyder_okvim/executor/executor_vline.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 """Vertical line selection helper."""
-# %% Import
-# Standard library imports
+
+# Standard Libraries
 import re
 
-# Third party imports
+# Third Party Libraries
 from spyder.config.manager import CONF
 
-# Local imports
+# Project Libraries
 from spyder_okvim.executor.executor_base import (
     FUNC_INFO,
     RETURN_EXECUTOR_METHOD_INFO,

--- a/spyder_okvim/executor/mixins.py
+++ b/spyder_okvim/executor/mixins.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 """Mixin classes used by command executors."""
 
+# Standard Libraries
 from typing import Callable
 
+# Third Party Libraries
 from spyder.config.manager import CONF
+
+# Project Libraries
 from spyder_okvim.executor.executor_base import FUNC_INFO, RETURN_EXECUTOR_METHOD_INFO
 from spyder_okvim.spyder.config import CONF_SECTION
 

--- a/spyder_okvim/executor/tests/test_colon.py
+++ b/spyder_okvim/executor/tests/test_colon.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests for :mod:`spyder_okvim.executor.executor_colon`."""
-# Third party imports
+
+# Third Party Libraries
 import pytest
 from qtpy.QtCore import Qt
 

--- a/spyder_okvim/executor/tests/test_easymotion.py
+++ b/spyder_okvim/executor/tests/test_easymotion.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests for the executor_easymotion."""
-# Third party imports
+
+# Third Party Libraries
 import pytest
 from qtpy.QtCore import Qt
 

--- a/spyder_okvim/executor/tests/test_leader_key.py
+++ b/spyder_okvim/executor/tests/test_leader_key.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 """Tests for the executor_leader_key."""
-# Standard library imports
+
+# Standard Libraries
 from unittest.mock import Mock
 
-# Third party imports
+# Third Party Libraries
 import pytest
 from qtpy.QtCore import Qt
 

--- a/spyder_okvim/executor/tests/test_normal.py
+++ b/spyder_okvim/executor/tests/test_normal.py
@@ -1,18 +1,19 @@
 # -*- coding: utf-8 -*-
 """Tests for the executor_normal."""
-# Standard library imports
+
+# Standard Libraries
 from unittest.mock import Mock
 
-# Third party imports
+# Third Party Libraries
 import pytest
 from qtpy.QtCore import QEvent, Qt
 from qtpy.QtGui import QKeyEvent, QTextCursor
 from qtpy.QtWidgets import QApplication
 from spyder.config.manager import CONF
 
-# Local imports
+# Project Libraries
 from spyder_okvim.spyder.config import CONF_SECTION
-from spyder_okvim.spyder.widgets import coverage_resolve_trace
+from spyder_okvim.spyder.vim_widgets import enable_coverage_tracing
 
 
 def test_unknown_cmd(vim_bot):
@@ -2530,7 +2531,7 @@ def test_q_cmd(vim_bot):
     qtbot.keyClicks(cmd_line, "@a")
 
     # to meet coverage
-    foo = coverage_resolve_trace(print)
+    foo = enable_coverage_tracing(print)
     foo()
 
 

--- a/spyder_okvim/executor/tests/test_surround.py
+++ b/spyder_okvim/executor/tests/test_surround.py
@@ -1,8 +1,9 @@
 """Tests for the executor_surround."""
 
-# Third party imports
+# Third Party Libraries
 import pytest
 
+# Project Libraries
 from spyder_okvim.utils.vim_status import VimState
 
 

--- a/spyder_okvim/executor/tests/test_visual.py
+++ b/spyder_okvim/executor/tests/test_visual.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 """Tests for the executor_visual."""
-# Third party imports
+
+# Third Party Libraries
 import pytest
 from qtpy.QtCore import Qt
 from spyder.config.manager import CONF
 
-# Local imports
+# Project Libraries
 from spyder_okvim.spyder.config import CONF_SECTION
 from spyder_okvim.utils.vim_status import VimState
 

--- a/spyder_okvim/executor/tests/test_vline.py
+++ b/spyder_okvim/executor/tests/test_vline.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 """Tests for the executor_vline."""
-# Third party imports
+
+# Third Party Libraries
 import pytest
 from qtpy.QtCore import Qt
 from spyder.config.manager import CONF
 
-# Local imports
+# Project Libraries
 from spyder_okvim.spyder.config import CONF_SECTION
 from spyder_okvim.utils.vim_status import VimState
 

--- a/spyder_okvim/spyder/api.py
+++ b/spyder_okvim/spyder/api.py
@@ -4,10 +4,9 @@
 #
 # Licensed under the terms of the MIT license
 # ----------------------------------------------------------------------------
-"""
-Spyder Custom Layout API.
-"""
+"""Spyder Custom Layout API."""
 
+# Third Party Libraries
 from spyder.api.plugins import Plugins
 from spyder.plugins.layout.api import BaseGridLayoutType
 

--- a/spyder_okvim/spyder/config.py
+++ b/spyder_okvim/spyder/config.py
@@ -4,7 +4,8 @@
 # Licensed under the terms of the MIT License
 
 """Spyder okvim default configuration."""
-# Third party imports
+
+# Third Party Libraries
 from qtpy.QtCore import Qt
 
 CONF_SECTION = "spyder_okvim"

--- a/spyder_okvim/spyder/confpage.py
+++ b/spyder_okvim/spyder/confpage.py
@@ -4,10 +4,10 @@
 # Licensed under the terms of the MIT License
 """Spyder okvim configuration page."""
 
-# Third party imports
+# Third Party Libraries
 from qtpy.QtCore import QRegExp, Qt
-from qtpy.QtGui import QRegExpValidator, QKeySequence
-from qtpy.QtWidgets import QGridLayout, QGroupBox, QHBoxLayout, QVBoxLayout, QLineEdit
+from qtpy.QtGui import QKeySequence, QRegExpValidator
+from qtpy.QtWidgets import QGridLayout, QGroupBox, QHBoxLayout, QLineEdit, QVBoxLayout
 from spyder.api.preferences import PluginConfigPage
 
 

--- a/spyder_okvim/spyder/plugin.py
+++ b/spyder_okvim/spyder/plugin.py
@@ -6,7 +6,8 @@
 # (see LICENSE.txt for details)
 # -----------------------------------------------------------------------------
 """OkVim Plugin."""
-# Third party imports
+
+# Third Party Libraries
 import qtawesome as qta
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtGui import QKeySequence
@@ -16,11 +17,11 @@ from spyder.api.plugins import Plugins, SpyderDockablePlugin
 from spyder.api.widgets.status import StatusBarWidget
 from spyder.utils.icon_manager import MAIN_FG_COLOR
 
-# Local imports
+# Project Libraries
 from spyder_okvim.spyder.api import CustomLayout
 from spyder_okvim.spyder.config import CONF_DEFAULTS, CONF_SECTION, CONF_VERSION
 from spyder_okvim.spyder.confpage import OkvimConfigPage
-from spyder_okvim.spyder.widgets import SpyderOkVimPane, VimWidget
+from spyder_okvim.spyder.vim_widgets import VimPane, VimWidget
 
 
 class StatusBarVimWidget(StatusBarWidget):
@@ -99,7 +100,7 @@ class OkVim(SpyderDockablePlugin):  # pylint: disable=R0904
     NAME = CONF_SECTION
     REQUIRES = [Plugins.StatusBar, Plugins.Preferences]
     OPTIONAL = []
-    WIDGET_CLASS = SpyderOkVimPane
+    WIDGET_CLASS = VimPane
     CONF_SECTION = CONF_SECTION
     CONF_WIDGET_CLASS = OkvimConfigPage
     CONF_DEFAULTS = CONF_DEFAULTS

--- a/spyder_okvim/spyder/tests/test_bookmarks.py
+++ b/spyder_okvim/spyder/tests/test_bookmarks.py
@@ -1,10 +1,10 @@
 """Tests for the Marks."""
 
-# %% Imports
-# Third party imports
+# Third Party Libraries
 import pytest
 from qtpy.QtCore import Qt
 
+# Project Libraries
 from spyder_okvim.utils.vim_status import VimState
 
 

--- a/spyder_okvim/spyder/tests/test_widgets.py
+++ b/spyder_okvim/spyder/tests/test_widgets.py
@@ -4,12 +4,13 @@
 # Licensed under the terms of the MIT License
 #
 """Tests for the plugin."""
-# Third party imports
+
+# Third Party Libraries
 import pytest
 from qtpy.QtCore import QEvent, Qt
 from qtpy.QtGui import QFocusEvent, QKeyEvent
 
-# Local imports
+# Project Libraries
 from spyder_okvim.spyder.confpage import OkvimConfigPage
 
 

--- a/spyder_okvim/utils/action_helpers.py
+++ b/spyder_okvim/utils/action_helpers.py
@@ -1,21 +1,26 @@
 # -*- coding: utf-8 -*-
 """Utility functions that implement Vim-style editing actions."""
-# %% Import
-# Standard library imports
+
+# Standard Libraries
 import re
 
-# Third party imports
+# Third Party Libraries
 from qtpy.QtGui import QTextCursor
 
-# Local imports
-from spyder_okvim.utils.helper_motion import HelperMotion, MotionInfo, MotionType
+# Project Libraries
+from spyder_okvim.utils.motion_helpers import MotionHelper, MotionInfo, MotionType
 from spyder_okvim.utils.vim_status import VimState
 
 
-class HelperAction:
-    """Helper for vim action."""
+class ActionHelper:
+    """Perform editing actions driven by Vim commands."""
 
     def __init__(self, vim_status):
+        """Initialize helper with the shared Vim status.
+
+        Args:
+            vim_status: Object managing editor and cursor state.
+        """
         self.vim_status = vim_status
         self.get_editor = vim_status.get_editor
         self.get_cursor = vim_status.get_cursor
@@ -28,7 +33,7 @@ class HelperAction:
         self.get_block_no_end_in_selection = vim_status.get_block_no_end_in_selection
         self.get_pos_start_in_selection = vim_status.get_pos_start_in_selection
         self.get_pos_end_in_selection = vim_status.get_pos_end_in_selection
-        self.helper_motion = HelperMotion(vim_status)
+        self.helper_motion = MotionHelper(vim_status)
 
     def join_lines(self, cursor_pos_start: int, block_no_start: int, block_no_end: int):
         """Join lines."""

--- a/spyder_okvim/utils/bookmark_manager.py
+++ b/spyder_okvim/utils/bookmark_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+# Standard Libraries
 import json
 import os
 import os.path as osp

--- a/spyder_okvim/utils/easymotion.py
+++ b/spyder_okvim/utils/easymotion.py
@@ -1,19 +1,20 @@
 # -*- coding: utf-8 -*-
 """Implementation of EasyMotion overlays."""
 
-# Standard library imports
+# Standard Libraries
 from itertools import product
 
-# Third party imports
+# Third Party Libraries
 from qtpy.QtCore import QCoreApplication, QEvent, QObject, Qt
 from qtpy.QtGui import QColor, QPainter, QPen
 from qtpy.QtWidgets import QPlainTextEdit, QWidget
 
 
-class ManageMarkerEasymotion:
-    """Manage markers of easymotion."""
+class EasyMotionMarkerManager:
+    """Manage overlay marker assignments."""
 
     def __init__(self):
+        """Initialize empty marker sets."""
         self.position_list: list[int] = []
         self.name_list: list[str] = []
 
@@ -53,14 +54,19 @@ class ManageMarkerEasymotion:
         self.name_list = names
 
 
-class PainterEasyMotion(QObject):
-    """Draw symbols for easymotion to QPlainTextEdit.
+class EasyMotionPainter(QObject):
+    """Draw overlay markers for EasyMotion in a text editor.
 
     Ref: github.com/serpheroth/QtCreator-EasyMotion
 
     """
 
     def __init__(self, editor: QPlainTextEdit = None):
+        """Create painter.
+
+        Args:
+            editor: Widget receiving overlay rendering.
+        """
         super().__init__()
         self.editor = editor
         self.positions = []

--- a/spyder_okvim/utils/motion_helpers.py
+++ b/spyder_okvim/utils/motion_helpers.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 """Cursor movement helpers for Vim emulation."""
-# %% Import
-# Standard library imports
+
+# Standard Libraries
 import re
 from bisect import bisect_left, bisect_right
 
-# Third party imports
+# Third Party Libraries
 from qtpy.QtCore import QPoint, QRegularExpression
 from qtpy.QtGui import QTextCursor, QTextDocument
 from qtpy.QtWidgets import QTextEdit
 from spyder.config.manager import CONF
 
-# Local imports
+# Project Libraries
 from spyder_okvim.spyder.config import CONF_SECTION
-from spyder_okvim.utils.misc import BRACKET_PAIR
+from spyder_okvim.utils.text_constants import BRACKET_PAIR
 
 WHITE_SPACE = " \t"
 
@@ -37,10 +37,15 @@ class MotionInfo:
         self.motion_type = MotionType.LineWise
 
 
-class HelperMotion:
-    """Helper for vim motion."""
+class MotionHelper:
+    """Utilities for computing cursor motions."""
 
     def __init__(self, vim_status):
+        """Create helper bound to the given Vim status object.
+
+        Args:
+            vim_status: Object providing editor utilities.
+        """
         self.vim_status = vim_status
         self.get_editor = vim_status.get_editor
         self.get_cursor = vim_status.get_cursor

--- a/spyder_okvim/utils/tests/test_file_search.py
+++ b/spyder_okvim/utils/tests/test_file_search.py
@@ -1,29 +1,30 @@
 # -*- coding: utf-8 -*-
-"""Tests for path finder."""
-# Third party imports
+"""Tests for the file search dialog."""
+
+# Third Party Libraries
 import pytest
 from qtpy.QtCore import QEvent, Qt
 from qtpy.QtGui import QKeyEvent
 
-# Local imports
-from spyder_okvim.utils.path_finder import PathFinder
+# Project Libraries
+from spyder_okvim.utils.file_search import FileSearchDialog
 
 
-def test_open_path_finder(vim_bot, monkeypatch, tmpdir):
-    """Test open path finder."""
+def test_open_file_search(vim_bot, monkeypatch, tmpdir):
+    """Test opening the file search dialog."""
     _, _, _, vim, qtbot = vim_bot
 
     fn = tmpdir.join("tmp.txt")
     fn.write("content")
-    monkeypatch.setattr(PathFinder, "exec_", lambda x: x)
-    monkeypatch.setattr(PathFinder, "get_path_selected", lambda x: str(fn))
+    monkeypatch.setattr(FileSearchDialog, "exec_", lambda x: x)
+    monkeypatch.setattr(FileSearchDialog, "get_selected_path", lambda x: str(fn))
     event = QKeyEvent(QEvent.KeyPress, Qt.Key_P, Qt.ControlModifier)
     vim.vim_cmd.commandline.keyPressEvent(event)
 
 
-def test_invaild_folder(qtbot):
-    """Test if input of path finder is invalid."""
-    pf = PathFinder(None)
+def test_invalid_folder(qtbot):
+    """Test dialog behavior with an invalid folder."""
+    pf = FileSearchDialog(None)
     qtbot.addWidget(pf)
     pf.show()
 
@@ -61,12 +62,12 @@ def test_invaild_folder(qtbot):
 
     event = QKeyEvent(QEvent.KeyPress, Qt.Key_Enter, Qt.NoModifier)
     edit.keyPressEvent(event)
-    assert pf.get_path_selected() == ""
+    assert pf.get_selected_path() == ""
 
     pf.show()
     event = QKeyEvent(QEvent.KeyPress, Qt.Key_Escape, Qt.NoModifier)
     edit.keyPressEvent(event)
-    assert pf.get_path_selected() == ""
+    assert pf.get_selected_path() == ""
 
 
 def test_valid_folder(qtbot, tmpdir):
@@ -81,7 +82,7 @@ def test_valid_folder(qtbot, tmpdir):
         tmp = folder_sub.join(name)
         tmp.write("contents")
 
-    pf = PathFinder(str(folder))
+    pf = FileSearchDialog(str(folder))
 
     qtbot.addWidget(pf)
     pf.show()
@@ -132,4 +133,4 @@ def test_valid_folder(qtbot, tmpdir):
 
     qtbot.keyClicks(edit, "ok9")
     qtbot.keyPress(edit, Qt.Key_Enter)
-    assert pf.get_path_selected() != ""
+    assert pf.get_selected_path() != ""

--- a/spyder_okvim/utils/text_constants.py
+++ b/spyder_okvim/utils/text_constants.py
@@ -1,3 +1,3 @@
-"""Miscellaneous constants and helpers."""
+"""Constants used for text processing."""
 
 BRACKET_PAIR = {"(": ")", ")": "(", "[": "]", "]": "[", "{": "}", "}": "{"}

--- a/spyder_okvim/utils/vim_status.py
+++ b/spyder_okvim/utils/vim_status.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 """Container for the state shared by all executors."""
 
-# Standard library imports
+# Standard Libraries
 import os.path as osp
 from collections import defaultdict
 
-# Third party imports
+# Third Party Libraries
 from qtpy.QtCore import QEvent, QObject, QRegularExpression, Qt, QTimer, Signal, Slot
 from qtpy.QtGui import (
     QBrush,
@@ -20,11 +20,11 @@ from qtpy.QtWidgets import QApplication, QLabel, QTextEdit
 from spyder.config.manager import CONF
 from spyder.plugins.editor.api.decoration import DRAW_ORDERS
 
-# Local imports
+# Project Libraries
 from spyder_okvim.spyder.config import CONF_SECTION
 from spyder_okvim.utils.bookmark_manager import BookmarkManager
-from spyder_okvim.utils.easymotion import ManageMarkerEasymotion, PainterEasyMotion
-from spyder_okvim.utils.helper_motion import MotionInfo, MotionType
+from spyder_okvim.utils.easymotion import EasyMotionMarkerManager, EasyMotionPainter
+from spyder_okvim.utils.motion_helpers import MotionInfo, MotionType
 
 
 class VimState:
@@ -696,8 +696,8 @@ class VimStatus(QObject):
         self.bookmarks_global = self.bookmark_manager.bookmarks_global
 
         # easymotion
-        self.painter_easymotion = PainterEasyMotion()
-        self.manager_marker_easymotion = ManageMarkerEasymotion()
+        self.painter_easymotion = EasyMotionPainter()
+        self.manager_marker_easymotion = EasyMotionMarkerManager()
         self.editor_connected_easymotion = None
 
         # Sneak


### PR DESCRIPTION
## Summary
- rename `widgets.py` to `vim_widgets.py`
- rename `SpyderOkVimPane` to `VimPane`
- rename `VimMsgLabel` to `VimMessageLabel`
- rename `WorkerMacro` to `MacroPlaybackWorker`
- replace `misc.py` with `text_constants.py`
- update imports and tests for new names

## Testing
- `pytest spyder_okvim/utils/tests/test_file_search.py::test_open_file_search -q`
- `pytest spyder_okvim/executor/tests/test_normal.py::test_unknown_cmd -q`


------
https://chatgpt.com/codex/tasks/task_e_6855dee1bdbc832db9d4862c6c656970