### PR TITLE
Refactor input cmd handling

### DIFF
--- a/spyder_okvim/executor/executor_base.py
+++ b/spyder_okvim/executor/executor_base.py
@@ -80,11 +80,18 @@ class ExecutorBase:
         self.pattern_cmd = None
         self.allow_leaderkey = True
 
-    def update_input_cmd_info(self, num_str, cmd, input_txt):
-        """Update input cmd to vim_status."""
+    def set_input_cmd_info(self, num_str, cmd):
+        """Record a new command into :class:`VimStatus`."""
+
         self.vim_status.input_cmd_prev.set(self.vim_status.input_cmd)
         self.vim_status.input_cmd.num_str = num_str
         self.vim_status.input_cmd.cmd = cmd
+
+    def append_input_cmd_info(self, input_txt):
+        """Append raw text to the current command."""
+
+        self.vim_status.input_cmd_prev.set(self.vim_status.input_cmd)
+        self.vim_status.input_cmd.append(input_txt)
 
     def set_parent_info_to_submode(self, submode, num, num_str):
         """Set info to submode."""
@@ -114,7 +121,7 @@ class ExecutorBase:
             num_str, key = match.groups()
 
         num = int(num_str) if num_str else 1
-        self.update_input_cmd_info(num_str, key, txt)
+        self.set_input_cmd_info(num_str, key)
 
         key = self.SYMBOLS_REPLACEMENT.get(key, key)
 
@@ -172,6 +179,6 @@ class ExecutorSubBase(ExecutorBase):
                 func_info.func()
         return self.return_deferred
 
-    def update_input_cmd_info(self, num_str, cmd, input_txt):
-        """Add input cmd to vim_status."""
-        self.vim_status.input_cmd.cmd += input_txt
+    def append_input_cmd_info(self, input_txt):
+        """Append text to the stored command."""
+        self.vim_status.input_cmd.append(input_txt)

--- a/spyder_okvim/executor/executor_colon.py
+++ b/spyder_okvim/executor/executor_colon.py
@@ -41,7 +41,7 @@ class ExecutorColon(ExecutorSubBase):
 
         # ':' is saved to input cmd_info at ExecutorBase.
         # So we need only txt[1:].
-        self.update_input_cmd_info(None, None, txt[1:])
+        self.append_input_cmd_info(txt[1:])
 
         txt = txt[1:-1]  # remove :, \r
         cmd = txt.split(None, 1)

--- a/spyder_okvim/executor/executor_sub.py
+++ b/spyder_okvim/executor/executor_sub.py
@@ -33,7 +33,7 @@ class ExecutorSubMotion_i(ExecutorSubBase):
 
     def __call__(self, txt):
         """Parse command and execute."""
-        self.update_input_cmd_info(None, None, txt)
+        self.append_input_cmd_info(txt)
         self.vim_status.sub_mode = None
 
         if txt in "wW{}[]()'\"bB":
@@ -67,7 +67,7 @@ class ExecutorSubMotion_a(ExecutorSubBase):
 
     def __call__(self, txt):
         """Parse command and execute."""
-        self.update_input_cmd_info(None, None, txt)
+        self.append_input_cmd_info(txt)
         self.vim_status.sub_mode = None
 
         if txt in "w{}[]()'\"bB":
@@ -119,7 +119,7 @@ class ExecutorSubMotion(ExecutorSubBase):
             else:
                 num_str = txt[:-1]
                 num = int(num_str)
-            self.update_input_cmd_info(num_str, cmd, txt)
+            self.append_input_cmd_info(txt)
 
             self.vim_status.sub_mode = None
 
@@ -632,7 +632,7 @@ class ExecutorSubCmd_register(ExecutorSubBase):
 
     def __call__(self, ch: str):
         """Update command to vim status."""
-        self.update_input_cmd_info(None, None, ch)
+        self.append_input_cmd_info(ch)
 
         self.vim_status.sub_mode = None
 
@@ -651,7 +651,7 @@ class ExecutorSubCmd_f_t(ExecutorSubBase):
         ch_previous = self.vim_status.input_cmd.cmd[-1]
         method = self.helper_motion.find_cmd_map.get(ch_previous, None)
 
-        self.update_input_cmd_info(None, None, ch)
+        self.append_input_cmd_info(ch)
 
         self.vim_status.sub_mode = None
 
@@ -680,7 +680,7 @@ class ExecutorSubCmdSneak(ExecutorSubBase):
         ch_previous = self.vim_status.input_cmd.cmd[-1]
         method = self.helper_motion.find_cmd_map.get(ch_previous, None)
 
-        self.update_input_cmd_info(None, None, ch2)
+        self.append_input_cmd_info(ch2)
 
         self.vim_status.sub_mode = None
 
@@ -707,7 +707,7 @@ class ExecutorSubCmd_r(ExecutorSubBase):
 
     def __call__(self, ch: str):
         """Replace the character under the cursor with ch."""
-        self.update_input_cmd_info(None, None, ch)
+        self.append_input_cmd_info(ch)
 
         self.helper_action.replace_txt_with_ch(self.pos_start, self.pos_end, ch)
 
@@ -772,7 +772,7 @@ class ExecutorSearch(ExecutorSubBase):
 
         # '/' is saved to input cmd_info at ExecutorBase.
         # So we need only txt[1:].
-        self.update_input_cmd_info(None, None, txt[1:])
+        self.append_input_cmd_info(txt[1:])
 
         txt = txt[1:-1]  # remove /, \r
 
@@ -792,7 +792,7 @@ class ExecutorSubCmd_alnum(ExecutorSubBase):
 
     def __call__(self, ch: str):
         """Return deferred result when ``ch`` is alphanumeric."""
-        self.update_input_cmd_info(None, None, ch)
+        self.append_input_cmd_info(ch)
 
         self.vim_status.sub_mode = None
 

--- a/spyder_okvim/executor/executor_surround.py
+++ b/spyder_okvim/executor/executor_surround.py
@@ -49,7 +49,7 @@ class ExecutorAddSurround(ExecutorSubBase):
         ch = ch.replace("B", "}")
 
         if ch in SURROUNDINGS:
-            self.update_input_cmd_info(None, None, ch)
+            self.append_input_cmd_info(ch)
             self.helper_action.add_surrounding(self.pos_start, self.pos_end, ch)
 
         self.vim_status.to_normal()
@@ -75,7 +75,7 @@ class ExecutorDeleteSurround(ExecutorSubBase):
         ch = ch.replace("B", "}")
 
         if ch in SURROUNDINGS:
-            self.update_input_cmd_info(None, None, ch)
+            self.append_input_cmd_info(ch)
             motion_info = self.helper_action.delete_surrounding(ch)
             if isinstance(motion_info.sel_start, int):
                 self.vim_status.to_normal()
@@ -104,7 +104,7 @@ class ExecutorChangeSurround(ExecutorSubBase):
         txt = txt.replace("B", "}")
 
         if txt[0] in SURROUNDINGS and txt[1] in SURROUNDINGS:
-            self.update_input_cmd_info(None, None, txt)
+            self.append_input_cmd_info(txt)
             motion_info = self.helper_action.change_surrounding(txt[0], txt[1])
             if isinstance(motion_info.sel_start, int):
                 self.vim_status.to_normal()

--- a/spyder_okvim/utils/vim_status.py
+++ b/spyder_okvim/utils/vim_status.py
@@ -67,6 +67,10 @@ class InputCmdInfo:
         self.num_str = input_cmd_info.num_str
         self.cmd = input_cmd_info.cmd
 
+    def append(self, txt):
+        """Append text to the current command string."""
+        self.cmd += txt
+
 
 class DotCmdInfo:
     """Dot command info."""


### PR DESCRIPTION
## Summary
- use explicit APIs to record input commands
- adjust sub executors to append raw input via the new API
- expose `InputCmdInfo.append` helper

## Testing
- `pytest -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_685611a07078832d92719a016741808a