### PR TITLE
Enhance close_file handling

### DIFF
--- a/spyder_okvim/executor/executor_base.py
+++ b/spyder_okvim/executor/executor_base.py
@@ -175,3 +175,11 @@ class ExecutorSubBase(ExecutorBase):
     def update_input_cmd_info(self, num_str, cmd, input_txt):
         """Add input cmd to vim_status."""
         self.vim_status.input_cmd.cmd += input_txt
+
+    # ------------------------------------------------------------------
+    # Common editor actions
+    # ------------------------------------------------------------------
+    def close_current_file(self) -> None:
+        """Close the current file using Spyder's editor API."""
+        widget = self.vim_status.editor_widget.get_widget()
+        widget.close_file()

--- a/spyder_okvim/executor/executor_colon.py
+++ b/spyder_okvim/executor/executor_colon.py
@@ -72,13 +72,13 @@ class ExecutorColon(ExecutorSubBase):
 
     def q(self, arg=""):
         """Close current file."""
-        self.editor_widget.get_widget().close_file()
+        self.close_current_file()
         self.vim_status.set_focus_to_vim()
 
     def qexclamation(self, arg=""):
         """Close current file without saving."""
         # TODO :
-        self.editor_widget.get_widget().close_file()
+        self.close_current_file()
         self.vim_status.set_focus_to_vim()
 
     def wq(self, arg=""):

--- a/spyder_okvim/executor/executor_sub.py
+++ b/spyder_okvim/executor/executor_sub.py
@@ -732,13 +732,13 @@ class ExecutorSubCmd_Z(ExecutorSubBase):
     def Q(self, num=1, num_str=""):
         """Close current file without saving."""
         # TODO :
-        self.editor_widget.get_widget().close_file()
+        self.close_current_file()
         self.vim_status.set_focus_to_vim()
 
     def Z(self, num=1, num_str=""):
         """Save and close current file."""
         self.editor_widget.get_widget().save_action.trigger()
-        self.editor_widget.get_widget().close_file()
+        self.close_current_file()
         self.vim_status.set_focus_to_vim()
 
 

--- a/spyder_okvim/executor/tests/test_colon.py
+++ b/spyder_okvim/executor/tests/test_colon.py
@@ -73,6 +73,18 @@ def test_colon_q_command(vim_bot):
     qtbot.keyClicks(cmd_line, ":")
     qtbot.keyClicks(cmd_line, "q")
     qtbot.keyPress(cmd_line, Qt.Key_Return)
+    main.editor.close_file.assert_called_once_with()
+    main.editor.close_file.reset_mock()
+
+
+def test_colon_q_command_without_close_file(vim_bot):
+    """Test :q when close_file API is missing."""
+    main, editor_stack, editor, vim, qtbot = vim_bot
+    orig_close_file = main.editor.close_file
+    delattr(main.editor, "close_file")
+    with pytest.raises(AttributeError):
+        vim.vim_cmd.executor_normal_cmd.executor_colon.q()
+    main.editor.close_file = orig_close_file
 
 
 def test_colon_qexclamation_command(vim_bot):
@@ -83,6 +95,8 @@ def test_colon_qexclamation_command(vim_bot):
     qtbot.keyClicks(cmd_line, "q")
     qtbot.keyClicks(cmd_line, "!")
     qtbot.keyPress(cmd_line, Qt.Key_Return)
+    main.editor.close_file.assert_called_once_with()
+    main.editor.close_file.reset_mock()
 
 
 def test_colon_wq_command(vim_bot):
@@ -94,7 +108,9 @@ def test_colon_wq_command(vim_bot):
     qtbot.keyClicks(cmd_line, "q")
     qtbot.keyPress(cmd_line, Qt.Key_Return)
     main.editor.save_action.trigger.assert_called_once_with()
+    main.editor.close_file.assert_called_once_with()
     main.editor.save_action.trigger.reset_mock()
+    main.editor.close_file.reset_mock()
 
 
 def test_colon_n_command(vim_bot):

--- a/spyder_okvim/executor/tests/test_normal.py
+++ b/spyder_okvim/executor/tests/test_normal.py
@@ -1073,9 +1073,9 @@ def test_ZZ_cmd(vim_bot):
     cmd_line = vim.vim_cmd.commandline
     qtbot.keyClicks(cmd_line, "ZZ")
     main.editor.save_action.trigger.assert_called_once_with()
-    # main.editor.close_action.trigger.assert_called_once_with()
+    main.editor.close_file.assert_called_once_with()
     main.editor.save_action.trigger.reset_mock()
-    # main.editor.close_action.trigger.reset_mock()
+    main.editor.close_file.reset_mock()
 
 
 def test_ZQ_cmd(vim_bot):
@@ -1083,8 +1083,8 @@ def test_ZQ_cmd(vim_bot):
     main, editor_stack, editor, vim, qtbot = vim_bot
     cmd_line = vim.vim_cmd.commandline
     qtbot.keyClicks(cmd_line, "ZQ")
-    # main.editor.close_action.trigger.assert_called_once_with()
-    # main.editor.close_action.trigger.reset_mock()
+    main.editor.close_file.assert_called_once_with()
+    main.editor.close_file.reset_mock()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add `close_current_file` helper in `ExecutorBase`
- use new helper for `:q`, `:q!`, `ZZ` and `ZQ`
- verify `close_file` is invoked in normal and ex-mode tests
- expect failure if `close_file` attribute is missing

## Testing
- `pytest spyder_okvim/executor/tests/test_colon.py::test_colon_q_command -vv`
- `pytest spyder_okvim/executor/tests/test_colon.py::test_colon_qexclamation_command -vv`
- `pytest spyder_okvim/executor/tests/test_colon.py::test_colon_wq_command -vv`
- `pytest spyder_okvim/executor/tests/test_normal.py::test_ZZ_cmd -vv`
- `pytest spyder_okvim/executor/tests/test_normal.py::test_ZQ_cmd -vv`


------
https://chatgpt.com/codex/tasks/task_e_68570325d364832da87e98131624b33a