### PR TITLE
Refactor vim_status modules

### DIFF
--- a/spyder_okvim/executor/executor_normal.py
+++ b/spyder_okvim/executor/executor_normal.py
@@ -270,7 +270,7 @@ class ExecutorNormalCmd(MovementMixin, ExecutorBase):
         """Run previous change."""
         # avoid to execute . command twice.
         self.vim_status.manager_macro.remove_last_key(".")
-        cmd_str = self.vim_status.dot_cmd.cmd2string(num, num_str)
+        cmd_str = self.vim_status.dot_cmd.to_cmd_string(num, num_str)
 
         if not cmd_str:
             return
@@ -647,3 +647,5 @@ class ExecutorNormalCmd(MovementMixin, ExecutorBase):
         """Search word under cursor backward."""
         motion_info = self.helper_motion.sharp(num)
         self.apply_motion_info_in_normal(motion_info)
+
+

--- a/spyder_okvim/utils/vim_status/__init__.py
+++ b/spyder_okvim/utils/vim_status/__init__.py
@@ -14,8 +14,8 @@ from .state import (
     RegisterInfo,
 )
 from .search import SearchInfo
-from .macro import MacroManager, ManagerMacro
-from .label import InlineLabel, LabelOnTxt
+from .macro import MacroManager
+from .label import InlineLabel
 from .cursor import VimCursor
 from .status import VimStatus
 
@@ -28,9 +28,9 @@ __all__ = [
     "RegisterInfo",
     "SearchInfo",
     "MacroManager",
-    "ManagerMacro",
     "InlineLabel",
-    "LabelOnTxt",
     "VimCursor",
     "VimStatus",
 ]
+
+

--- a/spyder_okvim/utils/vim_status/cursor.py
+++ b/spyder_okvim/utils/vim_status/cursor.py
@@ -93,12 +93,9 @@ class VimCursor:
     def create_selection(self, start, end):
         """Create a text selection between two positions.
 
-        Parameters
-        ----------
-        start
-            Starting position of the selection.
-        end
-            End position of the selection.
+        Args:
+            start: Starting position of the selection.
+            end: End position of the selection.
         """
         end_document = self.get_end_position()
         if end > end_document:
@@ -114,10 +111,8 @@ class VimCursor:
     def set_cursor_pos_in_visual(self, pos_new):
         """Move the cursor while adjusting the current visual selection.
 
-        Parameters
-        ----------
-        pos_new
-            Desired new cursor position.
+        Args:
+            pos_new: Desired new cursor position.
         """
         if pos_new is None:
             return
@@ -239,10 +234,8 @@ class VimCursor:
     def set_cursor_pos_in_vline(self, pos_new):
         """Move the cursor while updating the visual line selection.
 
-        Parameters
-        ----------
-        pos_new
-            Desired new cursor position.
+        Args:
+            pos_new: Desired new cursor position.
         """
         if pos_new is None:
             return
@@ -280,10 +273,8 @@ class VimCursor:
     def set_block_selection_in_visual(self, motion_info: MotionInfo):
         """Update block-wise visual selection from ``motion_info``.
 
-        Parameters
-        ----------
-        motion_info
-            Motion information computed by a helper.
+        Args:
+            motion_info: Motion information computed by a helper.
         """
         editor = self.get_editor()
         sel = editor.get_extra_selections("vim_selection")[0]
@@ -295,10 +286,8 @@ class VimCursor:
     def set_cursor_pos(self, pos):
         """Place the editor cursor at ``pos``.
 
-        Parameters
-        ----------
-        pos
-            New absolute position for the cursor.
+        Args:
+            pos: New absolute position for the cursor.
         """
         if pos is None:
             return
@@ -311,10 +300,8 @@ class VimCursor:
     def set_cursor_pos_without_end(self, pos):
         """Set the cursor avoiding the final block boundary.
 
-        Parameters
-        ----------
-        pos
-            Desired cursor position.
+        Args:
+            pos: Desired cursor position.
         """
         if pos is None:
             return
@@ -374,3 +361,5 @@ class VimCursor:
         QTimer.singleShot(
             self.hl_yank_dur, lambda: editor.clear_extra_selections("hl_yank")
         )
+
+

--- a/spyder_okvim/utils/vim_status/label.py
+++ b/spyder_okvim/utils/vim_status/label.py
@@ -14,7 +14,12 @@ class InlineLabel(QLabel):
         self.setWindowFlags(Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint)
 
     def set_style(self, font_family: str, font_size_pt: int):
-        """Apply styling for display."""
+        """Apply styling for display.
+
+        Args:
+            font_family: Font family name.
+            font_size_pt: Size of the font in points.
+        """
         self.setStyleSheet(
             f"""QLabel {{
             background-color : #222b35;
@@ -29,6 +34,5 @@ class InlineLabel(QLabel):
         )
 
 
-# Backwards compatibility -------------------------------------------------
-# Keep the previous name for external imports
-LabelOnTxt = InlineLabel
+
+

--- a/spyder_okvim/utils/vim_status/macro.py
+++ b/spyder_okvim/utils/vim_status/macro.py
@@ -29,12 +29,9 @@ class MacroManager:
     def set_info_for_execute(self, register, count):
         """Configure macro execution.
 
-        Parameters
-        ----------
-        register
-            Name of the register to execute.
-        count
-            Number of times to repeat execution.
+        Args:
+            register: Name of the register to execute.
+            count: Number of times to repeat execution.
         """
         self.reg_name_for_execute = register
         self.num_execute = count
@@ -42,10 +39,8 @@ class MacroManager:
     def start_record(self, register):
         """Begin recording keystrokes.
 
-        Parameters
-        ----------
-        register
-            Name of the register to store the recording in.
+        Args:
+            register: Name of the register to store the recording in.
         """
         self.reg_name_for_record = register
         self.is_recording = True
@@ -63,10 +58,8 @@ class MacroManager:
     def remove_last_key(self, text):
         """Remove a trailing key from the recording if it matches ``text``.
 
-        Parameters
-        ----------
-        text
-            Character to remove from the end of the recorded sequence.
+        Args:
+            text: Character to remove from the end of the recorded sequence.
         """
         key_list = self.registers[self.reg_name_for_record]
         if key_list:
@@ -90,12 +83,9 @@ class MacroManager:
     def connect_to_editor(self, editor: QObject, slot):
         """Start receiving key events from ``editor``.
 
-        Parameters
-        ----------
-        editor
-            Editor emitting ``sig_key_pressed``.
-        slot
-            Slot connected to the editor signal.
+        Args:
+            editor: Editor emitting ``sig_key_pressed``.
+            slot: Slot connected to the editor signal.
         """
         self.editor_connected = editor
         editor.sig_key_pressed.connect(slot)
@@ -112,6 +102,5 @@ class MacroManager:
         self.editor_connected = None
 
 
-# Backwards compatibility -------------------------------------------------
-# Retain the previous class name "ManagerMacro" for external imports.
-ManagerMacro = MacroManager
+
+

--- a/spyder_okvim/utils/vim_status/search.py
+++ b/spyder_okvim/utils/vim_status/search.py
@@ -21,10 +21,8 @@ class SearchInfo:
     def __init__(self, vim_cursor):
         """Initialize the search state.
 
-        Parameters
-        ----------
-        vim_cursor
-            Cursor helper used to draw selections.
+        Args:
+            vim_cursor: Cursor helper used to draw selections.
         """
         self.color_fg = QBrush(QColor("#A9B7C6"))
         self.color_bg = QBrush(QColor("#30652F"))
@@ -68,3 +66,5 @@ class SearchInfo:
         )
 
         return [i.cursor.selectionStart() for i in self.selection_list]
+
+

--- a/spyder_okvim/utils/vim_status/state.py
+++ b/spyder_okvim/utils/vim_status/state.py
@@ -25,12 +25,9 @@ class FindInfo:
     def set(self, cmd_name: str, ch: str):
         """Update this command information.
 
-        Parameters
-        ----------
-        cmd_name
-            Command name (``f``/``F``/``t``/``T``).
-        ch
-            Character used with the command.
+        Args:
+            cmd_name: Command name (``f``/``F``/``t``/``T``).
+            ch: Character used with the command.
         """
         self.cmd_name = cmd_name
         self.ch = ch
@@ -40,6 +37,12 @@ class InputCmdInfo:
     """Container for the command currently being typed."""
 
     def __init__(self, num_str: str, cmd: str):
+        """Create a new instance.
+
+        Args:
+            num_str: Number prefix for the command.
+            cmd: Command string.
+        """
         self.num_str: str = num_str
         self.cmd: str = cmd
 
@@ -49,7 +52,11 @@ class InputCmdInfo:
         self.cmd = ""
 
     def set(self, input_cmd_info):
-        """Copy the fields from another :class:`InputCmdInfo`."""
+        """Copy the fields from another ``InputCmdInfo``.
+
+        Args:
+            input_cmd_info: Source command info to copy from.
+        """
         self.num_str = input_cmd_info.num_str
         self.cmd = input_cmd_info.cmd
 
@@ -77,7 +84,12 @@ class DotCmdInfo:
         self.key_list_to_cmd_line.clear()
 
     def to_cmd_string(self, num, num_str):
-        """Return the textual representation of this dot command."""
+        """Return the textual representation of this dot command.
+
+        Args:
+            num: Numeric prefix used for the command.
+            num_str: Original numeric string typed by the user.
+        """
         # TODO : apply register name.
         cmd_str = ""
 
@@ -109,8 +121,6 @@ class DotCmdInfo:
         else:
             return self.num_str + self.cmd
 
-    # Backwards compatibility
-    cmd2string = to_cmd_string
 
 
 class KeyInfo:
@@ -138,3 +148,5 @@ class RegisterInfo:
         self.name = ""
         self.content = ""
         self.type = VimState.NORMAL
+
+


### PR DESCRIPTION
## Summary
- drop backward compatibility aliases
- adjust imports to use new class names
- modernize docstrings to Google style
- remove unused alias methods
- update normal executor for new dot command method

## Testing
- `pytest -q` *(fails: Fatal Python error: Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6857508c7a20832db256cf30310e6fd7