### PR TITLE
Refactor motion helpers

### DIFF
--- a/spyder_okvim/executor/executor_easymotion.py
+++ b/spyder_okvim/executor/executor_easymotion.py
@@ -15,7 +15,7 @@ from spyder_okvim.executor.executor_base import (
     RETURN_EXECUTOR_METHOD_INFO,
     ExecutorSubBase,
 )
-from spyder_okvim.utils.motion_helpers import MotionInfo, MotionType
+from spyder_okvim.utils.motion import MotionInfo, MotionType
 
 
 class ExecutorSelectMarkerEasymotion(ExecutorSubBase):

--- a/spyder_okvim/executor/executor_normal.py
+++ b/spyder_okvim/executor/executor_normal.py
@@ -43,7 +43,7 @@ from spyder_okvim.executor.executor_sub import (
 )
 from spyder_okvim.executor.mixins import MovementMixin
 from spyder_okvim.spyder.config import CONF_SECTION
-from spyder_okvim.utils.motion_helpers import MotionInfo, MotionType
+from spyder_okvim.utils.motion import MotionInfo, MotionType
 
 
 class ExecutorNormalCmd(MovementMixin, ExecutorBase):

--- a/spyder_okvim/executor/executor_surround.py
+++ b/spyder_okvim/executor/executor_surround.py
@@ -2,7 +2,7 @@
 
 # Project Libraries
 from spyder_okvim.executor.executor_base import ExecutorSubBase
-from spyder_okvim.utils.motion_helpers import MotionInfo, MotionType
+from spyder_okvim.utils.motion import MotionInfo, MotionType
 
 SURROUNDINGS = "'\"{[()]}"
 

--- a/spyder_okvim/utils/action_helpers.py
+++ b/spyder_okvim/utils/action_helpers.py
@@ -8,7 +8,8 @@ import re
 from qtpy.QtGui import QTextCursor
 
 # Project Libraries
-from spyder_okvim.utils.motion_helpers import MotionHelper, MotionInfo, MotionType
+from spyder_okvim.utils.motion import MotionInfo, MotionType
+from spyder_okvim.utils.motion_helpers import MotionHelper
 from spyder_okvim.vim import VimState
 
 

--- a/spyder_okvim/utils/motion.py
+++ b/spyder_okvim/utils/motion.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+
+
+class MotionType(IntEnum):
+    """Types of cursor motions."""
+
+    BlockWise = 0
+    LineWise = 1
+    CharWise = 2
+    CharWiseIncludingEnd = 3
+
+
+@dataclass
+class MotionInfo:
+    """Information about a computed motion."""
+
+    cursor_pos: int | None = None
+    sel_start: int | None = None
+    sel_end: int | None = None
+    motion_type: MotionType = MotionType.LineWise

--- a/spyder_okvim/utils/search_helpers.py
+++ b/spyder_okvim/utils/search_helpers.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from bisect import bisect_left, bisect_right
+from typing import Callable
+
+from qtpy.QtCore import QPoint, QRegularExpression
+from qtpy.QtGui import QTextCursor, QTextDocument
+from qtpy.QtWidgets import QTextEdit
+from spyder.config.manager import CONF
+
+from spyder_okvim.spyder.config import CONF_SECTION
+from spyder_okvim.utils.motion import MotionInfo, MotionType
+
+
+class SearchHelper:
+    """Helper routines for search-related motions."""
+
+    def __init__(self, vim_status, set_motion_info: Callable[..., MotionInfo]):
+        self.vim_status = vim_status
+        self.get_editor = vim_status.get_editor
+        self.get_cursor = vim_status.get_cursor
+        self._set_motion_info = set_motion_info
+
+    # ------------------------------------------------------------------
+    # Viewport helpers
+    # ------------------------------------------------------------------
+    def get_viewport_positions(self) -> tuple[int, int]:
+        """Return start and end character positions of the visible viewport."""
+        editor = self.get_editor()
+        start_pos = editor.cursorForPosition(QPoint(0, 0)).position()
+        bottom_right = QPoint(
+            editor.viewport().width() - 1, editor.viewport().height() - 1
+        )
+        end_pos = editor.cursorForPosition(bottom_right).position()
+        return start_pos, end_pos
+
+    def search_forward_in_view(self, text: str) -> list[int]:
+        """Return cursor positions of ``text`` inside the viewport."""
+        editor = self.get_editor()
+        cur_pos = editor.textCursor().position()
+        view_start, view_end = self.get_viewport_positions()
+        start_pos = min(view_end, cur_pos) + 1
+        positions: list[int] = []
+        while view_start <= start_pos <= view_end:
+            cursor = editor.document().find(text, start_pos, QTextDocument.FindCaseSensitively)
+            if cursor.isNull() or cursor.position() > view_end:
+                break
+            positions.append(cursor.position() - len(text))
+            start_pos = cursor.position()
+        return positions
+
+    def search_backward_in_view(self, text: str) -> list[int]:
+        """Return positions of ``text`` when searching backward in the viewport."""
+        editor = self.get_editor()
+        cur_pos = editor.textCursor().position()
+        view_start, view_end = self.get_viewport_positions()
+        start_pos = min(view_end, cur_pos)
+        positions: list[int] = []
+        while view_start <= start_pos <= view_end:
+            cursor = editor.document().find(
+                text,
+                start_pos,
+                QTextDocument.FindCaseSensitively | QTextDocument.FindBackward,
+            )
+            if cursor.isNull() or cursor.position() < view_start:
+                break
+            positions.append(cursor.position() - len(text))
+            start_pos = cursor.position() - len(text) - 1
+        return positions
+
+    # ------------------------------------------------------------------
+    # Sneak motions
+    # ------------------------------------------------------------------
+    def sneak(self, chars: str, num: int = 1, by_repeat_cmd: bool = False) -> MotionInfo:
+        """Jump forward to the given two-character sequence within the viewport."""
+        if not by_repeat_cmd:
+            self.vim_status.find_info.set("s", chars)
+        pos = None
+        positions = self.search_forward_in_view(chars)
+        if positions:
+            pos = positions[(num - 1) % len(positions)]
+        return self._set_motion_info(pos, motion_type=MotionType.CharWise)
+
+    def display_another_group_after_sneak(self) -> None:
+        """Show annotations for additional sneak targets."""
+        positions = self.search_forward_in_view(self.vim_status.find_info.ch)
+        info_group = {pos + 1: f"{idx};" if idx != 1 else ";" for idx, pos in enumerate(positions, 1)}
+        self.vim_status.annotate_on_txt(info_group, timeout=1500)
+
+    def rsneak(self, chars: str, num: int = 1, by_repeat_cmd: bool = False) -> MotionInfo:
+        """Jump backward to the given two-character sequence within the viewport."""
+        if not by_repeat_cmd:
+            self.vim_status.find_info.set("S", chars)
+        pos = None
+        positions = self.search_backward_in_view(chars)
+        if positions:
+            pos = positions[(num - 1) % len(positions)]
+        return self._set_motion_info(pos, motion_type=MotionType.CharWise)
+
+    def display_another_group_after_rsneak(self) -> None:
+        """Show annotations for additional reverse sneak targets."""
+        positions = self.search_backward_in_view(self.vim_status.find_info.ch)
+        info_group = {pos + 1: f"{idx};" if idx != 1 else ";" for idx, pos in enumerate(positions, 1)}
+        self.vim_status.annotate_on_txt(info_group, timeout=1500)
+
+    # ------------------------------------------------------------------
+    # Search in document
+    # ------------------------------------------------------------------
+    def search(self, text: str) -> None:
+        """Highlight all occurrences of ``text`` in the document."""
+        editor = self.get_editor()
+        cursor = QTextCursor(editor.document())
+        cursor.movePosition(QTextCursor.Start)
+
+        is_ignorecase = CONF.get(CONF_SECTION, "ignorecase")
+        is_smartcase = CONF.get(CONF_SECTION, "smartcase")
+
+        option = None
+        if is_ignorecase:
+            self.vim_status.search.ignorecase = True
+            if is_smartcase and text.lower() != text:
+                option = QTextDocument.FindCaseSensitively
+                self.vim_status.search.ignorecase = False
+        else:
+            option = QTextDocument.FindCaseSensitively
+            self.vim_status.search.ignorecase = False
+
+        back = self.vim_status.search.color_bg
+        fore = self.vim_status.search.color_fg
+        search_stack = []
+        while True:
+            if option:
+                cursor = editor.document().find(QRegularExpression(text), cursor, options=option)
+            else:
+                cursor = editor.document().find(QRegularExpression(text), cursor)
+
+            if cursor.position() != -1:
+                selection = QTextEdit.ExtraSelection()
+                selection.format.setBackground(back)
+                selection.format.setForeground(fore)
+                selection.cursor = cursor
+                search_stack.append(selection)
+            else:
+                break
+
+        self.vim_status.cursor.set_extra_selections("vim_search", [i for i in search_stack])
+        self.vim_status.search.selection_list = search_stack
+        self.vim_status.search.txt_searched = text
+
+    def n(self, num: int = 1, num_str: str = "") -> MotionInfo:
+        """Move to the next search match."""
+        positions = self.vim_status.search.get_sel_start_list()
+        if not positions:
+            return self._set_motion_info(None)
+        text = self.vim_status.search.txt_searched
+        self.vim_status.set_message(f"/{text}")
+        cursor_pos = self.get_cursor().position()
+        idx = bisect_right(positions, cursor_pos)
+        if idx == len(positions):
+            idx = 0
+        idx = (idx + num - 1) % len(positions)
+        return self._set_motion_info(positions[idx], motion_type=MotionType.CharWise)
+
+    def N(self, num: int = 1, num_str: str = "") -> MotionInfo:
+        """Move to the previous search match."""
+        positions = self.vim_status.search.get_sel_start_list()
+        if not positions:
+            return self._set_motion_info(None)
+        text = self.vim_status.search.txt_searched
+        self.vim_status.set_message(f"?{text}")
+        cursor_pos = self.get_cursor().position()
+        idx = bisect_left(positions, cursor_pos)
+        idx = (idx - (num - 1)) % len(positions)
+        return self._set_motion_info(positions[idx - 1], motion_type=MotionType.CharWise)
+
+    # ------------------------------------------------------------------
+    # Word searches
+    # ------------------------------------------------------------------
+    def _get_word_under_cursor(self) -> str | None:
+        editor = self.get_editor()
+        return editor.get_current_word()
+
+    def asterisk(self, num: int = 1, num_str: str = "") -> MotionInfo:
+        """Search forward for the word under the cursor."""
+        word = self._get_word_under_cursor()
+        if word is None:
+            return self._set_motion_info(None)
+        self.search(fr"\b{word}\b")
+        return self.n(num=num)
+
+    def sharp(self, num: int = 1, num_str: str = "") -> MotionInfo:
+        """Search backward for the word under the cursor."""
+        word = self._get_word_under_cursor()
+        if word is None:
+            return self._set_motion_info(None)
+        self.search(fr"\b{word}\b")
+        return self.N(num=num)

--- a/spyder_okvim/vim/cursor.py
+++ b/spyder_okvim/vim/cursor.py
@@ -8,7 +8,7 @@ from spyder.config.manager import CONF
 from spyder.plugins.editor.api.decoration import DRAW_ORDERS
 
 from spyder_okvim.spyder.config import CONF_SECTION
-from spyder_okvim.utils.motion_helpers import MotionInfo, MotionType
+from spyder_okvim.utils.motion import MotionInfo, MotionType
 
 
 class VimCursor:

--- a/spyder_okvim/vim/status.py
+++ b/spyder_okvim/vim/status.py
@@ -15,7 +15,7 @@ from spyder.config.manager import CONF
 from spyder_okvim.spyder.config import CONF_SECTION
 from spyder_okvim.utils.bookmark_manager import BookmarkManager
 from spyder_okvim.utils.easymotion import EasyMotionMarkerManager, EasyMotionPainter
-from spyder_okvim.utils.motion_helpers import MotionInfo, MotionType
+from spyder_okvim.utils.motion import MotionInfo, MotionType
 
 from .cursor import VimCursor
 from .label import InlineLabel


### PR DESCRIPTION
## Summary
- centralize motion info and types in `motion.py`
- split search operations into new `SearchHelper`
- delegate MotionHelper search-related functionality

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_6857e0424d58832d98d7d89e01c6a3d4