### PR TITLE
Add new vim command tests

### DIFF
--- a/spyder_okvim/executor/tests/test_normal.py
+++ b/spyder_okvim/executor/tests/test_normal.py
@@ -1533,6 +1533,27 @@ def test_clipboard(vim_bot):
     assert clipboard.text() == "1dhrwodn\n"
 
 
+def test_double_indent_unindent(vim_bot):
+    """Test >> and << commands."""
+    _, _, editor, vim, qtbot = vim_bot
+    editor.set_text("ab\n")
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(0)
+    vim.vim_cmd.vim_status.reset_for_test()
+
+    cmd_line = vim.vim_cmd.commandline
+    qtbot.keyClicks(cmd_line, ">>")
+
+    assert cmd_line.text() == ""
+    assert editor.toPlainText() == "    ab\n"
+    assert editor.textCursor().position() == 4
+
+    qtbot.keyClicks(cmd_line, "<<")
+
+    assert cmd_line.text() == ""
+    assert editor.toPlainText() == "ab\n"
+    assert editor.textCursor().position() == 0
+
+
 @pytest.mark.parametrize(
     "text, cmd_list, cursor_pos, register_name, text_yanked",
     [
@@ -1636,6 +1657,25 @@ def test_highlight_yank(vim_bot):
 
     sel = editor.get_extra_selections("hl_yank")
     assert len(sel) > 0
+
+
+def test_yy_cmd(vim_bot):
+    """Test yy command to yank a whole line."""
+    _, _, editor, vim, qtbot = vim_bot
+    editor.set_text("foo\nbar\n")
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(0)
+    vim.vim_cmd.vim_status.reset_for_test()
+
+    cmd_line = vim.vim_cmd.commandline
+    qtbot.keyClicks(cmd_line, "yy")
+
+    reg_default = vim.vim_cmd.vim_status.register_dict['"']
+    reg_zero = vim.vim_cmd.vim_status.register_dict["0"]
+
+    assert cmd_line.text() == ""
+    assert editor.textCursor().position() == 0
+    assert reg_default.content == "foo\n"
+    assert reg_zero.content == "foo\n"
 
 
 @pytest.mark.parametrize(

--- a/spyder_okvim/executor/tests/test_visual.py
+++ b/spyder_okvim/executor/tests/test_visual.py
@@ -950,6 +950,29 @@ def test_less_cmd_in_visual(vim_bot, text, cmd_list, text_expected, cursor_pos):
     assert vim.vim_cmd.vim_status.get_pos_start_in_selection() is None
 
 
+def test_double_indent_unindent_visual(vim_bot):
+    """Test >> and << in visual mode."""
+    _, _, editor, vim, qtbot = vim_bot
+    editor.set_text("a\n")
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(0)
+    vim.vim_cmd.vim_status.reset_for_test()
+
+    cmd_line = vim.vim_cmd.commandline
+    qtbot.keyClicks(cmd_line, "v")
+    qtbot.keyClicks(cmd_line, ">>")
+
+    assert cmd_line.text() == ""
+    assert editor.toPlainText() == "    a\n"
+    assert editor.textCursor().position() == 4
+
+    qtbot.keyClicks(cmd_line, "v")
+    qtbot.keyClicks(cmd_line, "<<")
+
+    assert cmd_line.text() == ""
+    assert editor.toPlainText() == "a\n"
+    assert editor.textCursor().position() == 0
+
+
 @pytest.mark.parametrize(
     "text, cmd_list, cursor_pos, sel_pos",
     [

--- a/spyder_okvim/executor/tests/test_vline.py
+++ b/spyder_okvim/executor/tests/test_vline.py
@@ -862,6 +862,29 @@ def test_less_cmd_in_vline(vim_bot, text, cmd_list, text_expected, cursor_pos):
     assert vim.vim_cmd.vim_status.get_pos_start_in_selection() is None
 
 
+def test_double_indent_unindent_vline(vim_bot):
+    """Test >> and << in visual line mode."""
+    _, _, editor, vim, qtbot = vim_bot
+    editor.set_text("a\n")
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(0)
+    vim.vim_cmd.vim_status.reset_for_test()
+
+    cmd_line = vim.vim_cmd.commandline
+    qtbot.keyClicks(cmd_line, "V")
+    qtbot.keyClicks(cmd_line, ">>")
+
+    assert cmd_line.text() == ""
+    assert editor.toPlainText() == "    a\n"
+    assert editor.textCursor().position() == 4
+
+    qtbot.keyClicks(cmd_line, "V")
+    qtbot.keyClicks(cmd_line, "<<")
+
+    assert cmd_line.text() == ""
+    assert editor.toPlainText() == "a\n"
+    assert editor.textCursor().position() == 0
+
+
 @pytest.mark.parametrize(
     "text, cmd_list, cursor_pos, register_name, text_yanked",
     [


### PR DESCRIPTION
## Summary
- add `yy` line yank test in normal mode
- cover `>>` and `<<` in normal, visual, and visual-line modes

## Testing
- `pytest spyder_okvim/executor/tests/test_normal.py::test_yy_cmd spyder_okvim/executor/tests/test_normal.py::test_double_indent_unindent spyder_okvim/executor/tests/test_visual.py::test_double_indent_unindent_visual spyder_okvim/executor/tests/test_vline.py::test_double_indent_unindent_vline -q`

------
https://chatgpt.com/codex/tasks/task_e_68581c570e90832da7d52c56fd7ee5d9