### PR TITLE
Refactor go-to-definition jump logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ Use `m{mark}` to set a mark at the current cursor position and `'` or \` to jump
 - ZZ : Save and close current file.
 - q, @: macro
 
+## Jump list
+
+The jump list is a core Vim feature that tracks recently visited
+locations. Okvim records each position so you can return with `Ctrl+o` and
+move forward with `Ctrl+i`. Locations are added when opening files with
+`Ctrl+p` and when running `gd`. Because Spyder's "go to definition" works
+asynchronously, Okvim pushes the current location immediately and adds the
+new one once navigation finishes. If the cursor never moves within two
+seconds, that temporary entry is discarded.
+
 ## Special keys
 
 - <leader>f : autoformat the curruent file
@@ -139,7 +149,9 @@ The following actions are supported:
 
 ## Fuzzy path finder
 
-Press Ctrl+p to open the fuzzy path finder.
+Press Ctrl+p to open the fuzzy path finder. Spyder uses the same shortcut as a
+global command, so you may need to reassign Spyder's default Ctrl+p binding to
+use this feature.
 Use ^p, ^n, ^f, ^b, ^u, and ^d to navigate the list.
 
 ![fuzzy path finder](https://github.com/ok97465/spyder_okvim/raw/main/doc/path_finder.gif)
@@ -174,3 +186,4 @@ For operators use `z` because `s` belongs to vim-surround.
 
 When there are matches in another group, hints appear around the group.
 ![sneak](https://github.com/ok97465/spyder_okvim/raw/main/doc/sneak.gif)
+

--- a/spyder_okvim/executor/executor_sub.py
+++ b/spyder_okvim/executor/executor_sub.py
@@ -544,8 +544,15 @@ class ExecutorSubCmd_g(ExecutorSubBase):
         return self.execute_func_deferred(motion_info)
 
     def d(self, num=1, num_str=""):
-        """Go to definition."""
-        self.get_editor().go_to_definition_from_cursor()
+        """Go to definition and update the jumplist."""
+        vs = self.vim_status
+        previous = vs.get_current_location()
+        vs.push_jump()
+
+        editor = self.get_editor()
+        if editor:
+            editor.go_to_definition_from_cursor()
+            vs.start_definition_tracking(previous)
 
     def t(self, num=1, num_str=""):
         """Cycle to next file."""

--- a/spyder_okvim/spyder/vim_widgets.py
+++ b/spyder_okvim/spyder/vim_widgets.py
@@ -278,7 +278,9 @@ class VimShortcut(QObject):
         path = dlg.get_selected_path()
 
         if osp.isfile(path):
+            self.vim_status.push_jump()
             self.main.open_file(path)
+            self.vim_status.jump_list.push(path, 0)
             self.vim_status.set_focus_to_vim()
 
     def clear_tip_search(self) -> None:

--- a/spyder_okvim/utils/jump_list.py
+++ b/spyder_okvim/utils/jump_list.py
@@ -42,3 +42,11 @@ class JumpList:
         jump = self.jumps[self.index]
         self.index += 1
         return jump
+
+    def pop_last(self) -> None:
+        """Remove the most recently added jump if present."""
+        if not self.jumps:
+            return
+        self.jumps.pop()
+        if self.index > len(self.jumps):
+            self.index = len(self.jumps)


### PR DESCRIPTION
## Summary
- streamline gd command jump handling
- share cursor location logic via `VimStatus.get_current_location`
- monitor navigation with `VimStatus.start_definition_tracking`

## Testing
- `pytest spyder_okvim/utils/tests/test_file_search.py::test_open_file_search -q`
- `pytest spyder_okvim/spyder/tests/test_widgets.py::test_jumplist_go_to_definition -q`
- `pytest -q` *(fails: Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_685b104eb2f4832d908eb733508dc65a