### PR TITLE
Improve dialog readability using tables

### DIFF
--- a/spyder_okvim/utils/file_search.py
+++ b/spyder_okvim/utils/file_search.py
@@ -117,7 +117,7 @@ class FileSearchDialog(PopupTableDialog):
         super().__init__(
             "Path Finder",
             parent=parent,
-            headers=["File", "Path"],
+            headers=["File", "Folder"],
             min_width=self._MIN_WIDTH,
             max_height=self._MAX_HEIGHT,
         )
@@ -194,6 +194,7 @@ class FileSearchDialog(PopupTableDialog):
                     it.setEditable(False)
                 self.list_model.appendRow(row)
             self.list_viewer.setCurrentIndex(self.list_model.index(0, 0))
+            self.list_viewer.selectRow(0)
 
     def enter(self) -> None:
         """Select next row in list viewer."""

--- a/spyder_okvim/utils/file_search.py
+++ b/spyder_okvim/utils/file_search.py
@@ -9,11 +9,11 @@ import sys
 
 # Third Party Libraries
 from qtpy.QtCore import QDir, QDirIterator, Qt, Signal
-from qtpy.QtGui import QKeyEvent
+from qtpy.QtGui import QKeyEvent, QStandardItem
 from qtpy.QtWidgets import QApplication, QDialog, QLineEdit, QWidget
 from spyder.config.gui import get_font
 
-from .list_dialog import PopupListDialog
+from .list_dialog import PopupTableDialog
 
 
 def fuzzyfinder(query: str, collection: list[str]) -> list[str]:
@@ -101,7 +101,7 @@ class FileSearchLineEdit(QLineEdit):
         super().keyPressEvent(e)
 
 
-class FileSearchDialog(PopupListDialog):
+class FileSearchDialog(PopupTableDialog):
     """Dialog used to select a file path from a project."""
 
     _MIN_WIDTH = 800
@@ -117,6 +117,7 @@ class FileSearchDialog(PopupListDialog):
         super().__init__(
             "Path Finder",
             parent=parent,
+            headers=["File", "Path"],
             min_width=self._MIN_WIDTH,
             max_height=self._MAX_HEIGHT,
         )
@@ -182,13 +183,23 @@ class FileSearchDialog(PopupListDialog):
             paths = fuzzyfinder(query, collections)
 
         if paths:
-            self.list_model.setStringList(paths)
-            self.list_viewer.setCurrentIndex(self.list_model.index(0))
+            self.list_model.setRowCount(0)
+            for path in paths:
+                basename = osp.basename(path)
+                dirname = osp.dirname(path)
+                item = QStandardItem(basename)
+                item.setData(path, Qt.UserRole)
+                row = [item, QStandardItem(dirname)]
+                for it in row:
+                    it.setEditable(False)
+                self.list_model.appendRow(row)
+            self.list_viewer.setCurrentIndex(self.list_model.index(0, 0))
 
     def enter(self) -> None:
         """Select next row in list viewer."""
         idx = self.list_viewer.currentIndex()
-        rel_path = idx.data(Qt.DisplayRole)
+        item = self.list_model.item(idx.row(), 0)
+        rel_path = item.data(Qt.UserRole) if item else None
         if rel_path and isinstance(self.folder, str):
             path = osp.join(self.folder, rel_path)
             self.path_selected = path

--- a/spyder_okvim/utils/jump_dialog.py
+++ b/spyder_okvim/utils/jump_dialog.py
@@ -69,14 +69,17 @@ class JumpListDialog(PopupTableDialog):
                 QStandardItem(basename),
                 QStandardItem(text),
             ]
-            for item in row:
+            for idx, item in enumerate(row):
                 item.setEditable(False)
+                if idx in (1, 2):
+                    item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
             self.list_model.appendRow(row)
 
     def update_current_row(self) -> None:
         row = max(0, self.jump_list.index - 1)
         if self.list_model.rowCount() > 0:
             self.list_viewer.setCurrentIndex(self.list_model.index(row, 0))
+            self.list_viewer.selectRow(row)
 
     # ------------------------------------------------------------------
     # Qt overrides

--- a/spyder_okvim/utils/jump_dialog.py
+++ b/spyder_okvim/utils/jump_dialog.py
@@ -6,10 +6,12 @@ import os.path as osp
 # Third Party Libraries
 from qtpy.QtCore import Qt
 
-from .list_dialog import PopupListDialog
+from qtpy.QtGui import QStandardItem
+
+from .list_dialog import PopupTableDialog
 
 
-class JumpListDialog(PopupListDialog):
+class JumpListDialog(PopupTableDialog):
     """Dialog to display the jump list."""
 
     _MIN_WIDTH = 800
@@ -19,6 +21,7 @@ class JumpListDialog(PopupListDialog):
         super().__init__(
             "Jumps",
             parent=parent,
+            headers=["#", "Line", "Col", "File", "Text"],
             min_width=self._MIN_WIDTH,
             max_height=self._MAX_HEIGHT,
         )
@@ -54,20 +57,26 @@ class JumpListDialog(PopupListDialog):
         return line + 1, col + 1, text
 
     def _populate(self) -> None:
-        items: list[str] = []
+        self.list_model.setRowCount(0)
         for i, jump in enumerate(self.jump_list.jumps, start=1):
             line, col, text = self._get_line_info(jump.file, jump.pos)
             basename = osp.basename(jump.file)
-            mark = ">" if i == self.jump_list.index else " "
-            items.append(
-                f"{mark}{i:>3} | {line:>5} | {col:>4} | {basename} | {text}"
-            )
-        self.list_model.setStringList(items)
+            mark = ">" if i == self.jump_list.index else ""
+            row = [
+                QStandardItem(f"{mark}{i}"),
+                QStandardItem(str(line)),
+                QStandardItem(str(col)),
+                QStandardItem(basename),
+                QStandardItem(text),
+            ]
+            for item in row:
+                item.setEditable(False)
+            self.list_model.appendRow(row)
 
     def update_current_row(self) -> None:
         row = max(0, self.jump_list.index - 1)
         if self.list_model.rowCount() > 0:
-            self.list_viewer.setCurrentIndex(self.list_model.index(row))
+            self.list_viewer.setCurrentIndex(self.list_model.index(row, 0))
 
     # ------------------------------------------------------------------
     # Qt overrides

--- a/spyder_okvim/utils/list_dialog.py
+++ b/spyder_okvim/utils/list_dialog.py
@@ -9,6 +9,7 @@ from qtpy.QtWidgets import (
     QTableView,
     QVBoxLayout,
     QHeaderView,
+    QAbstractItemView,
 )
 from spyder.config.gui import get_font
 
@@ -137,6 +138,7 @@ class PopupTableDialog(QDialog):
 
         self.list_viewer = QTableView(self)
         self.list_viewer.setSelectionBehavior(QTableView.SelectRows)
+        self.list_viewer.setSelectionMode(QAbstractItemView.SingleSelection)
         self.list_viewer.verticalHeader().setVisible(False)
         self.list_viewer.horizontalHeader().setStretchLastSection(True)
         if min_width:
@@ -175,6 +177,7 @@ class PopupTableDialog(QDialog):
         row = self.list_viewer.currentIndex().row() - stride
         row = max(row, 0)
         self.list_viewer.setCurrentIndex(self.list_model.index(row, 0))
+        self.list_viewer.selectRow(row)
 
     def next_row(self, stride: int = 1) -> None:
         """Select the next row."""
@@ -184,6 +187,7 @@ class PopupTableDialog(QDialog):
         row = self.list_viewer.currentIndex().row() + stride
         row = min(row, n_row - 1)
         self.list_viewer.setCurrentIndex(self.list_model.index(row, 0))
+        self.list_viewer.selectRow(row)
 
     def pg_up(self) -> None:
         """Scroll one page up."""

--- a/spyder_okvim/utils/list_dialog.py
+++ b/spyder_okvim/utils/list_dialog.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 # Third Party Libraries
 from qtpy.QtCore import QStringListModel, Qt
-from qtpy.QtWidgets import QDialog, QListView, QVBoxLayout
+from qtpy.QtGui import QStandardItem, QStandardItemModel
+from qtpy.QtWidgets import (
+    QDialog,
+    QListView,
+    QTableView,
+    QVBoxLayout,
+    QHeaderView,
+)
 from spyder.config.gui import get_font
 
 
@@ -36,9 +43,7 @@ class PopupListDialog(QDialog):
         self.list_model = QStringListModel()
         self.list_viewer.setModel(self.list_model)
         self.list_viewer.setFont(font)
-        self.list_viewer.setStyleSheet(
-            "QListView { color: #f0f0f0; }"
-        )
+        self.list_viewer.setStyleSheet("QListView { color: #f0f0f0; }")
 
         self.layout_ = QVBoxLayout()
         self.layout_.addWidget(self.list_viewer)
@@ -70,6 +75,115 @@ class PopupListDialog(QDialog):
         row = self.list_viewer.currentIndex().row() + stride
         row = min(row, n_row - 1)
         self.list_viewer.setCurrentIndex(self.list_model.index(row))
+
+    def pg_up(self) -> None:
+        """Scroll one page up."""
+        self.prev_row(self.get_number_of_visible_lines())
+
+    def pg_down(self) -> None:
+        """Scroll one page down."""
+        self.next_row(self.get_number_of_visible_lines())
+
+    def pg_half_up(self) -> None:
+        """Scroll half a page up."""
+        self.prev_row(self.get_number_of_visible_lines() // 2)
+
+    def pg_half_down(self) -> None:
+        """Scroll half a page down."""
+        self.next_row(self.get_number_of_visible_lines() // 2)
+
+    # ------------------------------------------------------------------
+    # Qt overrides
+    # ------------------------------------------------------------------
+    def keyPressEvent(self, event) -> None:  # noqa: D401
+        """Handle vim-like navigation keys."""
+        key = event.key()
+        mod = event.modifiers()
+        if mod == Qt.ControlModifier and key == Qt.Key_P:
+            self.prev_row()
+            return
+        if mod == Qt.ControlModifier and key == Qt.Key_N:
+            self.next_row()
+            return
+        if key in (Qt.Key_Return, Qt.Key_Enter):
+            self.accept()
+            return
+        if key == Qt.Key_Escape:
+            self.reject()
+            return
+        super().keyPressEvent(event)
+
+
+class PopupTableDialog(QDialog):
+    """Base dialog for displaying tabular data."""
+
+    def __init__(
+        self,
+        title: str,
+        parent=None,
+        *,
+        headers: list[str] | None = None,
+        min_width: int | None = None,
+        max_height: int = 600,
+    ) -> None:
+        super().__init__(parent)
+        font = get_font(font_size_delta=2)
+
+        self.setWindowTitle(title)
+        self.setWindowFlags(Qt.Popup | Qt.FramelessWindowHint)
+        self.setWindowOpacity(0.95)
+        self.setFont(font)
+        self.setAttribute(Qt.WA_DeleteOnClose)
+
+        self.list_viewer = QTableView(self)
+        self.list_viewer.setSelectionBehavior(QTableView.SelectRows)
+        self.list_viewer.verticalHeader().setVisible(False)
+        self.list_viewer.horizontalHeader().setStretchLastSection(True)
+        if min_width:
+            self.list_viewer.setMinimumWidth(min_width)
+        if max_height:
+            self.list_viewer.setFixedHeight(max_height)
+        self.list_model = QStandardItemModel()
+        if headers:
+            self.list_model.setHorizontalHeaderLabels(headers)
+        self.list_viewer.setModel(self.list_model)
+        self.list_viewer.setFont(font)
+        self.list_viewer.setStyleSheet("QTableView { color: #f0f0f0; }")
+        self.list_viewer.horizontalHeader().setSectionResizeMode(
+            QHeaderView.ResizeToContents
+        )
+        self.list_viewer.horizontalHeader().setStretchLastSection(True)
+
+        self.layout_ = QVBoxLayout()
+        self.layout_.addWidget(self.list_viewer)
+        self.setLayout(self.layout_)
+
+    # ------------------------------------------------------------------
+    # Navigation helpers (same as :class:`PopupListDialog`)
+    # ------------------------------------------------------------------
+    def get_number_of_visible_lines(self) -> int:
+        """Return the number of visible lines in the table."""
+        num_lines = 0
+        lv = self.list_viewer
+        height = lv.visualRect(self.list_model.index(0, 0)).height()
+        if height > 0:
+            num_lines = lv.viewport().height() // height
+        return num_lines
+
+    def prev_row(self, stride: int = 1) -> None:
+        """Select the previous row."""
+        row = self.list_viewer.currentIndex().row() - stride
+        row = max(row, 0)
+        self.list_viewer.setCurrentIndex(self.list_model.index(row, 0))
+
+    def next_row(self, stride: int = 1) -> None:
+        """Select the next row."""
+        n_row = self.list_model.rowCount()
+        if n_row == 0:
+            return
+        row = self.list_viewer.currentIndex().row() + stride
+        row = min(row, n_row - 1)
+        self.list_viewer.setCurrentIndex(self.list_model.index(row, 0))
 
     def pg_up(self) -> None:
         """Scroll one page up."""

--- a/spyder_okvim/utils/mark_dialog.py
+++ b/spyder_okvim/utils/mark_dialog.py
@@ -31,6 +31,7 @@ class MarkListDialog(PopupTableDialog):
         self._populate()
         if self.list_model.rowCount() > 0:
             self.list_viewer.setCurrentIndex(self.list_model.index(0, 0))
+            self.list_viewer.selectRow(0)
 
     def _populate(self) -> None:
         self.list_model.setRowCount(0)
@@ -54,8 +55,10 @@ class MarkListDialog(PopupTableDialog):
                 QStandardItem(basename),
                 QStandardItem(text),
             ]
-            for item in row:
+            for i, item in enumerate(row):
                 item.setEditable(False)
+                if i in (1, 2):
+                    item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
             self.list_model.appendRow(row)
 
     def get_selected_mark(self) -> str:

--- a/spyder_okvim/utils/mark_dialog.py
+++ b/spyder_okvim/utils/mark_dialog.py
@@ -5,11 +5,12 @@ import os.path as osp
 
 # Third Party Libraries
 from qtpy.QtCore import Qt
+from qtpy.QtGui import QStandardItem
 
-from .list_dialog import PopupListDialog
+from .list_dialog import PopupTableDialog
 
 
-class MarkListDialog(PopupListDialog):
+class MarkListDialog(PopupTableDialog):
     """Dialog to display bookmarks and allow jumping to them."""
 
     _MIN_WIDTH = 800
@@ -19,6 +20,7 @@ class MarkListDialog(PopupListDialog):
         super().__init__(
             "Marks",
             parent=parent,
+            headers=["Mark", "Line", "Col", "File", "Text"],
             min_width=self._MIN_WIDTH,
             max_height=self._MAX_HEIGHT,
         )
@@ -28,10 +30,10 @@ class MarkListDialog(PopupListDialog):
 
         self._populate()
         if self.list_model.rowCount() > 0:
-            self.list_viewer.setCurrentIndex(self.list_model.index(0))
+            self.list_viewer.setCurrentIndex(self.list_model.index(0, 0))
 
     def _populate(self) -> None:
-        items: list[str] = []
+        self.list_model.setRowCount(0)
         for mark, info in self.marks:
             file_path = info.get("file", "")
             line = info.get("line", 0)
@@ -45,10 +47,16 @@ class MarkListDialog(PopupListDialog):
             except Exception:
                 pass
             basename = osp.basename(file_path)
-            items.append(
-                f"{mark:>2} | {line + 1:>5} | {col + 1:>4} | {basename} | {text}"
-                )
-        self.list_model.setStringList(items)
+            row = [
+                QStandardItem(mark),
+                QStandardItem(str(line + 1)),
+                QStandardItem(str(col + 1)),
+                QStandardItem(basename),
+                QStandardItem(text),
+            ]
+            for item in row:
+                item.setEditable(False)
+            self.list_model.appendRow(row)
 
     def get_selected_mark(self) -> str:
         row = self.list_viewer.currentIndex().row()

--- a/spyder_okvim/utils/mark_dialog.py
+++ b/spyder_okvim/utils/mark_dialog.py
@@ -33,6 +33,23 @@ class MarkListDialog(PopupTableDialog):
             self.list_viewer.setCurrentIndex(self.list_model.index(0, 0))
             self.list_viewer.selectRow(0)
 
+    # ------------------------------------------------------------------
+    # Qt overrides
+    # ------------------------------------------------------------------
+    def accept(self) -> None:
+        """Store selected mark and close the dialog."""
+        row = self.list_viewer.currentIndex().row()
+        if 0 <= row < len(self.marks):
+            self.selected_mark = self.marks[row][0]
+        else:
+            self.selected_mark = ""
+        super().accept()
+
+    def reject(self) -> None:
+        """Clear selected mark when dialog is cancelled."""
+        self.selected_mark = ""
+        super().reject()
+
     def _populate(self) -> None:
         self.list_model.setRowCount(0)
         for mark, info in self.marks:
@@ -62,7 +79,5 @@ class MarkListDialog(PopupTableDialog):
             self.list_model.appendRow(row)
 
     def get_selected_mark(self) -> str:
-        row = self.list_viewer.currentIndex().row()
-        if 0 <= row < len(self.marks):
-            return self.marks[row][0]
-        return ""
+        """Return the mark selected by the user."""
+        return self.selected_mark


### PR DESCRIPTION
## Summary
- display lists in a new `PopupTableDialog`
- show file search paths, marks and jumps in table format for easier reading

## Testing
- `black spyder_okvim/utils/file_search.py spyder_okvim/utils/jump_dialog.py spyder_okvim/utils/mark_dialog.py spyder_okvim/utils/list_dialog.py`
- `pytest -q` *(fails: IndexError and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d880e19f4832d8e38362336b0765c