### PR TITLE
Implement [[ and ]] navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The following motions are supported:
 - ^D, ^U, ^F, ^B
 - HLM
 - %
+- [[, ]]
 - f, F, t, T, ;, ,
 - /, N, n
 - Enter, Space, Backspace

--- a/spyder_okvim/executor/executor_normal.py
+++ b/spyder_okvim/executor/executor_normal.py
@@ -632,21 +632,23 @@ class ExecutorNormalCmd(MovementMixin, ExecutorBase):
 
         return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
 
+    @submode(lambda self: [FUNC_INFO(self.apply_motion_info_in_normal, True)])
     def opensquarebracket(self, num=1, num_str=""):
         """Start [ submode."""
         executor_sub = self.executor_sub_opensquarebracekt
 
         self.set_parent_info_to_submode(executor_sub, num, num_str)
 
-        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
+        return executor_sub
 
+    @submode(lambda self: [FUNC_INFO(self.apply_motion_info_in_normal, True)])
     def closesquarebracket(self, num=1, num_str=""):
         """Start ] submode."""
         executor_sub = self.executor_sub_closesquarebracekt
 
         self.set_parent_info_to_submode(executor_sub, num, num_str)
 
-        return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
+        return executor_sub
 
     def asterisk(self, num=1, num_str=""):
         """Search word under cursor forward."""

--- a/spyder_okvim/executor/executor_sub.py
+++ b/spyder_okvim/executor/executor_sub.py
@@ -820,7 +820,7 @@ class ExecutorSubCmd_opensquarebracket(ExecutorSubBase):
 
         self.has_zero_cmd = False
 
-        cmds = "d"
+        cmds = ''.join(re.escape(c) for c in "d[")
         self.pattern_cmd = re.compile(r"(\d*)([{}])".format(cmds))
 
     def d(self, num=1, num_str=""):
@@ -830,6 +830,12 @@ class ExecutorSubCmd_opensquarebracket(ExecutorSubBase):
         for _ in range(num):
             editor.go_to_previous_warning()
         self.vim_status.cursor.draw_vim_cursor()
+
+    def opensquarebracket(self, num=1, num_str=""):
+        """Jump to previous Python definition."""
+        num = num * self.parent_num[0]
+        motion_info = self.helper_motion.prev_pydef(num)
+        return self.execute_func_deferred(motion_info)
 
 
 class ExecutorSubCmd_closesquarebracket(ExecutorSubBase):
@@ -842,7 +848,7 @@ class ExecutorSubCmd_closesquarebracket(ExecutorSubBase):
 
         self.has_zero_cmd = False
 
-        cmds = "d"
+        cmds = ''.join(re.escape(c) for c in "d]")
         self.pattern_cmd = re.compile(r"(\d*)([{}])".format(cmds))
 
     def d(self, num=1, num_str=""):
@@ -852,6 +858,12 @@ class ExecutorSubCmd_closesquarebracket(ExecutorSubBase):
         for _ in range(num):
             editor.go_to_next_warning()
         self.vim_status.cursor.draw_vim_cursor()
+
+    def closesquarebracket(self, num=1, num_str=""):
+        """Jump to next Python definition."""
+        num = num * self.parent_num[0]
+        motion_info = self.helper_motion.next_pydef(num)
+        return self.execute_func_deferred(motion_info)
 
 
 class ExecutorSubCmd_z(ExecutorSubBase):

--- a/spyder_okvim/executor/executor_visual.py
+++ b/spyder_okvim/executor/executor_visual.py
@@ -25,8 +25,10 @@ from spyder_okvim.executor.executor_easymotion import ExecutorEasymotion
 from spyder_okvim.executor.executor_sub import (
     ExecutorSearch,
     ExecutorSubCmd_alnum,
+    ExecutorSubCmd_closesquarebracket,
     ExecutorSubCmd_f_t,
     ExecutorSubCmd_g,
+    ExecutorSubCmd_opensquarebracket,
     ExecutorSubCmd_r,
     ExecutorSubCmd_register,
     ExecutorSubCmdSneak,
@@ -48,7 +50,7 @@ class ExecutorVisualCmd(SelectionMixin, MovementMixin, ExecutorBase):
         self.move_cursor = vim_status.cursor.set_cursor_pos_in_visual
         self.move_cursor_no_end = vim_status.cursor.set_cursor_pos_in_visual
 
-        cmds = "uUoiaydxscVhHjJklLMwWbBSepP^$gG~:%fFtTnN/;,\"`'mr<> \b\r*#"
+        cmds = "uUoiaydxscVhHjJklLMwWbBSepP^$gG~:%fFtTnN/;,\"`'mr<> \b\r[]*#"
         cmds = "".join(re.escape(c) for c in cmds)
         self.pattern_cmd = re.compile(r"(\d*)([{}])".format(cmds))
         self.set_cursor_pos = vim_status.cursor.set_cursor_pos
@@ -71,6 +73,12 @@ class ExecutorVisualCmd(SelectionMixin, MovementMixin, ExecutorBase):
         self.executor_sub_easymotion = ExecutorEasymotion(vim_status)
         self.executor_sub_sneak = ExecutorSubCmdSneak(vim_status)
         self.executor_sub_surround = ExecutorAddSurround(vim_status)
+        self.executor_sub_opensquarebracekt = ExecutorSubCmd_opensquarebracket(
+            vim_status
+        )
+        self.executor_sub_closesquarebracekt = (
+            ExecutorSubCmd_closesquarebracket(vim_status)
+        )
 
         # SelectionMixin hooks
         self.apply_motion_info_in_sel = self.apply_motion_info_in_visual
@@ -140,6 +148,16 @@ class ExecutorVisualCmd(SelectionMixin, MovementMixin, ExecutorBase):
     def T(self, num=1, num_str=""):
         """Go to the next occurrence of a character."""
         return self.executor_sub_f_t
+
+    @submode(lambda self: [FUNC_INFO(self.apply_motion_info_in_visual, True)])
+    def opensquarebracket(self, num=1, num_str=""):
+        """Start [ submode."""
+        return self.executor_sub_opensquarebracekt
+
+    @submode(lambda self: [FUNC_INFO(self.apply_motion_info_in_visual, True)])
+    def closesquarebracket(self, num=1, num_str=""):
+        """Start ] submode."""
+        return self.executor_sub_closesquarebracekt
 
     def i(self, num=1, num_str=""):
         """Select block exclusively."""

--- a/spyder_okvim/executor/executor_vline.py
+++ b/spyder_okvim/executor/executor_vline.py
@@ -13,13 +13,16 @@ from spyder_okvim.executor.executor_base import (
     RETURN_EXECUTOR_METHOD_INFO,
     ExecutorBase,
 )
+from spyder_okvim.executor.decorators import submode
 from spyder_okvim.executor.executor_colon import ExecutorColon
 from spyder_okvim.executor.executor_easymotion import ExecutorEasymotion
 from spyder_okvim.executor.executor_sub import (
     ExecutorSearch,
     ExecutorSubCmd_alnum,
+    ExecutorSubCmd_closesquarebracket,
     ExecutorSubCmd_f_t,
     ExecutorSubCmd_g,
+    ExecutorSubCmd_opensquarebracket,
     ExecutorSubCmd_r,
     ExecutorSubCmd_register,
     ExecutorSubCmdSneak,
@@ -38,7 +41,7 @@ class ExecutorVlineCmd(SelectionMixin, MovementMixin, ExecutorBase):
         self.move_cursor = vim_status.cursor.set_cursor_pos_in_vline
         self.move_cursor_no_end = vim_status.cursor.set_cursor_pos_in_vline
 
-        cmds = "uUovhydcsSxHjJklLMwWbBepP^$gG~:%fFtTnN/;,\"`'mr<> \b\r*#"
+        cmds = "uUovhydcsSxHjJklLMwWbBepP^$gG~:%fFtTnN/;,\"`'mr<> \b\r[]*#"
         cmds = "".join(re.escape(c) for c in cmds)
         self.pattern_cmd = re.compile(r"(\d*)([{}])".format(cmds))
         self.set_cursor_pos = vim_status.cursor.set_cursor_pos
@@ -55,6 +58,12 @@ class ExecutorVlineCmd(SelectionMixin, MovementMixin, ExecutorBase):
         self.executor_sub_easymotion = ExecutorEasymotion(vim_status)
         self.executor_sub_sneak = ExecutorSubCmdSneak(vim_status)
         self.executor_colon = ExecutorColon(vim_status)
+        self.executor_sub_opensquarebracekt = ExecutorSubCmd_opensquarebracket(
+            vim_status
+        )
+        self.executor_sub_closesquarebracekt = (
+            ExecutorSubCmd_closesquarebracket(vim_status)
+        )
 
         # SelectionMixin hooks
         self.apply_motion_info_in_sel = self.apply_motion_info_in_vline
@@ -152,6 +161,16 @@ class ExecutorVlineCmd(SelectionMixin, MovementMixin, ExecutorBase):
         )
 
         return RETURN_EXECUTOR_METHOD_INFO(executor_sub, True)
+
+    @submode(lambda self: [FUNC_INFO(self.apply_motion_info_in_vline, True)])
+    def opensquarebracket(self, num=1, num_str=""):
+        """Start [ submode."""
+        return self.executor_sub_opensquarebracekt
+
+    @submode(lambda self: [FUNC_INFO(self.apply_motion_info_in_vline, True)])
+    def closesquarebracket(self, num=1, num_str=""):
+        """Start ] submode."""
+        return self.executor_sub_closesquarebracekt
 
     def d(self, num=1, num_str=""):
         """Delete text."""

--- a/spyder_okvim/executor/tests/test_normal.py
+++ b/spyder_okvim/executor/tests/test_normal.py
@@ -2549,3 +2549,65 @@ def test_squarebracket_d_cmd(vim_bot):
     assert cmd_line.text() == ""
     assert editor.go_to_next_warning.called
     assert editor.go_to_previous_warning.called
+
+
+@pytest.mark.parametrize(
+    "start_line, cmd, expected",
+    [
+        (0, "]]", 2),
+        (6, "]]", 6),
+        (9, "]]", 9),
+    ],
+)
+def test_next_python_definition(vim_bot, start_line, cmd, expected):
+    """Jump to next Python function or class definition."""
+    _, _, editor, vim, qtbot = vim_bot
+
+    text = (
+        "import os\n\n"
+        "def a():\n    pass\n\n"
+        "class Foo:\n    def b(self):\n        pass\n\n"
+        "def c():\n    pass\n"
+    )
+    editor.set_text(text)
+
+    block = editor.document().findBlockByNumber(start_line)
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(block.position())
+    vim.vim_cmd.vim_status.reset_for_test()
+
+    cmd_line = vim.vim_cmd.commandline
+    qtbot.keyClicks(cmd_line, cmd)
+
+    assert cmd_line.text() == ""
+    assert editor.textCursor().blockNumber() == expected
+
+
+@pytest.mark.parametrize(
+    "start_line, cmd, expected",
+    [
+        (10, "[[", 9),
+        (6, "[[", 5),
+        (2, "[[", 2),
+    ],
+)
+def test_prev_python_definition(vim_bot, start_line, cmd, expected):
+    """Jump to previous Python function or class definition."""
+    _, _, editor, vim, qtbot = vim_bot
+
+    text = (
+        "import os\n\n"
+        "def a():\n    pass\n\n"
+        "class Foo:\n    def b(self):\n        pass\n\n"
+        "def c():\n    pass\n"
+    )
+    editor.set_text(text)
+
+    block = editor.document().findBlockByNumber(start_line)
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(block.position())
+    vim.vim_cmd.vim_status.reset_for_test()
+
+    cmd_line = vim.vim_cmd.commandline
+    qtbot.keyClicks(cmd_line, cmd)
+
+    assert cmd_line.text() == ""
+    assert editor.textCursor().blockNumber() == expected

--- a/spyder_okvim/executor/tests/test_visual.py
+++ b/spyder_okvim/executor/tests/test_visual.py
@@ -1580,3 +1580,67 @@ def test_jump_mark_in_visual(vim_bot):
     qtbot.keyClicks(cmd_line, "v'a")
     assert vim.vim_cmd.vim_status.vim_state == VimState.VISUAL
     assert editor.textCursor().position() == 0
+
+
+@pytest.mark.parametrize(
+    "start_line, cmd_list, expected",
+    [
+        (0, ["v", "]]"], 2),
+        (6, ["v", "]]"], 6),
+        (9, ["v", "]]"], 9),
+    ],
+)
+def test_next_python_definition_in_visual(vim_bot, start_line, cmd_list, expected):
+    """Jump to next Python definition while in Visual mode."""
+    _, _, editor, vim, qtbot = vim_bot
+
+    text = (
+        "import os\n\n"
+        "def a():\n    pass\n\n"
+        "class Foo:\n    def b(self):\n        pass\n\n"
+        "def c():\n    pass\n"
+    )
+    editor.set_text(text)
+
+    block = editor.document().findBlockByNumber(start_line)
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(block.position())
+    vim.vim_cmd.vim_status.reset_for_test()
+
+    cmd_line = vim.vim_cmd.commandline
+    for cmd in cmd_list:
+        qtbot.keyClicks(cmd_line, cmd)
+
+    assert cmd_line.text() == ""
+    assert editor.textCursor().blockNumber() == expected
+
+
+@pytest.mark.parametrize(
+    "start_line, cmd_list, expected",
+    [
+        (10, ["v", "[["], 9),
+        (6, ["v", "[["], 5),
+        (2, ["v", "[["], 2),
+    ],
+)
+def test_prev_python_definition_in_visual(vim_bot, start_line, cmd_list, expected):
+    """Jump to previous Python definition while in Visual mode."""
+    _, _, editor, vim, qtbot = vim_bot
+
+    text = (
+        "import os\n\n"
+        "def a():\n    pass\n\n"
+        "class Foo:\n    def b(self):\n        pass\n\n"
+        "def c():\n    pass\n"
+    )
+    editor.set_text(text)
+
+    block = editor.document().findBlockByNumber(start_line)
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(block.position())
+    vim.vim_cmd.vim_status.reset_for_test()
+
+    cmd_line = vim.vim_cmd.commandline
+    for cmd in cmd_list:
+        qtbot.keyClicks(cmd_line, cmd)
+
+    assert cmd_line.text() == ""
+    assert editor.textCursor().blockNumber() == expected

--- a/spyder_okvim/executor/tests/test_vline.py
+++ b/spyder_okvim/executor/tests/test_vline.py
@@ -1241,3 +1241,67 @@ def test_jump_mark_in_vline(vim_bot):
     qtbot.keyClicks(cmd_line, "V'a")
     assert vim.vim_cmd.vim_status.vim_state == VimState.VLINE
     assert editor.textCursor().position() == 0
+
+
+@pytest.mark.parametrize(
+    "start_line, cmd_list, expected",
+    [
+        (0, ["V", "]]"], 2),
+        (6, ["V", "]]"], 6),
+        (9, ["V", "]]"], 9),
+    ],
+)
+def test_next_python_definition_in_vline(vim_bot, start_line, cmd_list, expected):
+    """Jump to next Python definition while in Vline mode."""
+    _, _, editor, vim, qtbot = vim_bot
+
+    text = (
+        "import os\n\n"
+        "def a():\n    pass\n\n"
+        "class Foo:\n    def b(self):\n        pass\n\n"
+        "def c():\n    pass\n"
+    )
+    editor.set_text(text)
+
+    block = editor.document().findBlockByNumber(start_line)
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(block.position())
+    vim.vim_cmd.vim_status.reset_for_test()
+
+    cmd_line = vim.vim_cmd.commandline
+    for cmd in cmd_list:
+        qtbot.keyClicks(cmd_line, cmd)
+
+    assert cmd_line.text() == ""
+    assert editor.textCursor().blockNumber() == expected
+
+
+@pytest.mark.parametrize(
+    "start_line, cmd_list, expected",
+    [
+        (10, ["V", "[["], 9),
+        (6, ["V", "[["], 5),
+        (2, ["V", "[["], 2),
+    ],
+)
+def test_prev_python_definition_in_vline(vim_bot, start_line, cmd_list, expected):
+    """Jump to previous Python definition while in Vline mode."""
+    _, _, editor, vim, qtbot = vim_bot
+
+    text = (
+        "import os\n\n"
+        "def a():\n    pass\n\n"
+        "class Foo:\n    def b(self):\n        pass\n\n"
+        "def c():\n    pass\n"
+    )
+    editor.set_text(text)
+
+    block = editor.document().findBlockByNumber(start_line)
+    vim.vim_cmd.vim_status.cursor.set_cursor_pos(block.position())
+    vim.vim_cmd.vim_status.reset_for_test()
+
+    cmd_line = vim.vim_cmd.commandline
+    for cmd in cmd_list:
+        qtbot.keyClicks(cmd_line, cmd)
+
+    assert cmd_line.text() == ""
+    assert editor.textCursor().blockNumber() == expected


### PR DESCRIPTION
## Summary
- add AST-based helpers for finding Python definitions
- implement `[[` and `]]` motions through bracket submodes
- expose bracket submodes from normal mode
- test navigating between Python functions and classes

## Testing
- `pip install -q -r requirements/tests.txt`
- `python runtests.py`

------
https://chatgpt.com/codex/tasks/task_e_6869c09970a4832d866480144ec211e0