### PR TITLE
Support undocked editor windows in okvim

### DIFF
--- a/spyder_okvim/spyder/plugin.py
+++ b/spyder_okvim/spyder/plugin.py
@@ -191,7 +191,8 @@ class OkVim(SpyderDockablePlugin):  # pylint: disable=R0904
         """Add or remove extra command line based on editor window."""
         vim_cmd = self.get_widget().vim_cmd
 
-        window = QApplication.activeWindow()
+        focus = QApplication.focusWidget()
+        window = focus.window() if focus is not None else QApplication.activeWindow()
         if window is None:
             return
 
@@ -254,7 +255,7 @@ class OkVim(SpyderDockablePlugin):  # pylint: disable=R0904
         # Only handle Esc when the focus is inside the editor stack
         if focus is not editor and not editor.isAncestorOf(focus):
             return
-        window = QApplication.activeWindow()
+        window = focus.window()
         if window is self._main:
             editor_widget = vim_cmd.editor_widget.get_widget()
         elif hasattr(window, "editorwidget"):

--- a/spyder_okvim/spyder/plugin.py
+++ b/spyder_okvim/spyder/plugin.py
@@ -183,7 +183,12 @@ class OkVim(SpyderDockablePlugin):  # pylint: disable=R0904
             if signal is not None:
                 signal.connect(self._update_cmdline_location)
 
-    def _update_cmdline_location(self) -> None:
+        # Ensure the command line follows focus changes across windows so that
+        # newly created editor windows get their extra command line and Esc
+        # shortcut before the user presses Esc for the first time.
+        QApplication.instance().focusChanged.connect(self._update_cmdline_location)
+
+    def _update_cmdline_location(self, *_args) -> None:
         """Add or remove extra command line based on editor window."""
         vim_cmd = self.get_widget().vim_cmd
 

--- a/spyder_okvim/spyder/vim_widgets.py
+++ b/spyder_okvim/spyder/vim_widgets.py
@@ -415,6 +415,8 @@ class VimLineEdit(QLineEdit):
         if self.vim_status.cursor.get_editor():
             self.to_normal()
         self.vim_status.set_message("")
+        # Keep track of the command line currently receiving focus so that
+        # helpers know where to send output or shortcuts.
         self.vim_status.cmd_line = self
         self.vim_shortcut.cmd_line = self
 
@@ -533,7 +535,15 @@ class VimWidget(QWidget):
         self.leader_key = leader_key
         self.executor_leader_key.set_easymotion_key(self.leader_key)
     def process_command(self, txt: str, cmd_line: QLineEdit) -> None:
-        """Process input command from a command line."""
+        """Process an input command coming from a command line widget.
+
+        Parameters
+        ----------
+        txt: str
+            Text entered by the user.
+        cmd_line: QLineEdit
+            Command line that emitted the text change.
+        """
         if not txt:
             return
 


### PR DESCRIPTION
## Summary
- Keep main window status bar Vim widget while adding extra command lines for undocked or new editor windows
- Focus the correct command line when Esc is pressed in any editor window
- Allow multiple command lines to share execution logic

## Testing
- `QT_QPA_PLATFORM=offscreen pytest spyder_okvim/executor/tests/test_normal.py`

------
https://chatgpt.com/codex/tasks/task_e_689fcc8c0df0832da17aec5dad590719