### PR TITLE
Support floating editor windows with separate Vim command line

### DIFF
--- a/spyder_okvim/spyder/plugin.py
+++ b/spyder_okvim/spyder/plugin.py
@@ -10,8 +10,7 @@
 # Third Party Libraries
 import qtawesome as qta
 from qtpy.QtCore import Qt, Signal, QCoreApplication
-from qtpy.QtGui import QKeySequence
-from qtpy.QtWidgets import QHBoxLayout, QShortcut
+from qtpy.QtWidgets import QHBoxLayout
 from spyder.api.plugin_registration.decorators import on_plugin_available
 from spyder.api.plugins import Plugins, SpyderDockablePlugin
 
@@ -157,12 +156,7 @@ class OkVim(SpyderDockablePlugin):  # pylint: disable=R0904
 
         editorsplitter = vim_cmd.editor_widget.get_widget().editorsplitter
 
-        esc_shortcut = QShortcut(
-            QKeySequence("Esc"),
-            editorsplitter,
-            vim_cmd.commandline.setFocus,
-        )
-        esc_shortcut.setContext(Qt.WidgetWithChildrenShortcut)
+        vim_cmd.set_esc_shortcut(editorsplitter)
 
     @on_plugin_available(plugin=Plugins.Preferences)
     def on_preferences_available(self) -> None:


### PR DESCRIPTION
## Summary
- allow OkVim to create a minimal command line when the editor is undocked or opened in a new window
- manage ESC shortcuts so other panes keep normal behaviour

## Testing
- `pytest spyder_okvim/executor/tests/test_normal.py` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_689febcc94a0832d892d643af4c90e00