### PR TITLE
Support Vim command line for floating editor windows

### DIFF
--- a/spyder_okvim/vim/cursor.py
+++ b/spyder_okvim/vim/cursor.py
@@ -16,8 +16,9 @@ from spyder_okvim.utils.motion import MotionInfo, MotionType
 class VimCursor:
     """Manage the Vim cursor."""
 
-    def __init__(self, editor_widget):
+    def __init__(self, editor_widget, editor_window=None):
         self.editor_widget = editor_widget
+        self.editor_window = editor_window
 
         self.vim_cursor = QTextEdit.ExtraSelection()
         self.vim_cursor.format.setForeground(QBrush(QColor("#000000")))
@@ -63,11 +64,18 @@ class VimCursor:
 
     def get_editor(self):
         """Get the editor focused."""
-        editorstack = self.editor_widget.get_current_editorstack()
+        editorstack = self.get_editorstack()
         return editorstack.get_current_editor()
 
     def get_editorstack(self):
         """Get the editorstack."""
+        if self.editor_window is not None:
+            try:
+                return self.editor_widget.get_current_editorstack(
+                    self.editor_window
+                )
+            except TypeError:
+                pass
         return self.editor_widget.get_current_editorstack()
 
     def get_cursor(self):

--- a/spyder_okvim/vim/status.py
+++ b/spyder_okvim/vim/status.py
@@ -31,7 +31,11 @@ class VimStatus(QObject):
     change_label = Signal(int)
 
     def __init__(
-        self, editor_widget: QWidget, main: QWidget, msg_label: QLabel
+        self,
+        editor_widget: QWidget,
+        main: QWidget,
+        msg_label: QLabel | None,
+        editor_window=None,
     ) -> None:
         """Initialize the status object.
 
@@ -39,12 +43,13 @@ class VimStatus(QObject):
             editor_widget: Editor plugin used to access the current editor.
             main: Main Spyder window.
             msg_label: Label widget used to display status messages.
+            editor_window: Optional editor window for undocked or new instances.
         """
         super().__init__()
         self.is_visual_mode = False
         self.vim_state = VimState.NORMAL
         self.editor_widget = editor_widget
-        self.cursor: VimCursor = VimCursor(editor_widget)
+        self.cursor: VimCursor = VimCursor(editor_widget, editor_window)
         self.main = main
 
         # method mapping
@@ -169,7 +174,8 @@ class VimStatus(QObject):
         # Macro
         self.manager_macro = MacroManager()
 
-        self.msg_label.setText("")
+        if self.msg_label is not None:
+            self.msg_label.setText("")
 
         # bookmarks
         self.bookmark_manager.clear()
@@ -436,7 +442,8 @@ class VimStatus(QObject):
 
     def set_message(self, msg, duration_ms=-1):
         """Display ``msg`` in the status bar."""
-        self.msg_label.setText(f"{self.msg_prefix}{msg}")
+        if self.msg_label is not None:
+            self.msg_label.setText(f"{self.msg_prefix}{msg}")
 
     def start_recording_macro(self, reg_name):
         """Start recording macro."""


### PR DESCRIPTION
## Summary
- add per-window Vim command lines when the Editor is undocked or opened in a new window
- allow VimWidget to run without status or message labels for compact layouts
- propagate editor window context through VimCursor and VimStatus

## Testing
- `pytest spyder_okvim/executor/tests/test_normal.py`


------
https://chatgpt.com/codex/tasks/task_e_689febcc94a0832d892d643af4c90e00