### PR TITLE
Handle floating editors with per-window Vim command line

### DIFF
--- a/spyder_okvim/spyder/plugin.py
+++ b/spyder_okvim/spyder/plugin.py
@@ -164,6 +164,18 @@ class OkVim(SpyderDockablePlugin):  # pylint: disable=R0904
         )
         esc_shortcut.setContext(Qt.WidgetWithChildrenShortcut)
 
+        editor_plugin = vim_cmd.editor_widget
+        if hasattr(editor_plugin, "sig_editor_focus_changed"):
+            editor_plugin.sig_editor_focus_changed.connect(
+                vim_cmd.on_editor_focus_changed
+            )
+        if hasattr(editor_plugin, "dockwidget") and hasattr(
+            editor_plugin.dockwidget, "topLevelChanged"
+        ):
+            editor_plugin.dockwidget.topLevelChanged.connect(
+                vim_cmd.on_top_level_changed
+            )
+
     @on_plugin_available(plugin=Plugins.Preferences)
     def on_preferences_available(self) -> None:
         """Connect when preferences available."""


### PR DESCRIPTION
## Summary
- create standalone Vim command lines for floating or undocked editor windows
- allow VimLineEdit to use custom parents and update status when focused
- wire OkVim plugin to editor focus and docking changes

## Testing
- `pytest spyder_okvim/executor/tests/test_normal.py`

------
https://chatgpt.com/codex/tasks/task_e_68a1aac53dfc832db1e12ccf7983de68